### PR TITLE
优化祝福选择逻辑，删除重置祝福功能

### DIFF
--- a/actions/insect.json
+++ b/actions/insect.json
@@ -773,5 +773,19 @@
         [
             "is_run"
         ]
+    },
+    {
+        "name": "列车补给",
+        "trigger": {
+            "text": "列车补给",
+            "box": [880, 1039, 55, 97],
+            "interval": 2,
+            "redundancy": 5
+        },
+        "actions": [
+            {
+                "position": [1200, 1000]
+            }
+        ]
     }
 ]

--- a/simul.py
+++ b/simul.py
@@ -405,54 +405,29 @@ class SimulatedUniverse(UniverseUtils):
         return 1
     # 祝福界面/回响界面 （放在一起处理了）
     def choose_bless(self):
-        chose = 0
-        if self.click_text(text="重置祝福",box=[1268, 1444, 929, 1025],click=False,warning=False):
-            for _ in range(4):
-                img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask", fresh=True)
-                if self.ts.split_and_find(self.tk.fates, img_down, mode="bless")[1] or self._stop:
-                    break
-                if not self.click_text(text="选择祝福",box=[60, 222, 0, 113],click=False,ocr_line=False,warning=False):
-                    return 1
-            img_up = self.get_small_interaction_img(x=0.5047, y=0.5491, mask="mask_bless", fresh=True)
-            res_up = self.ts.split_and_find(self.tk.prior_bless, img_up, mode="bless_skip=self.tk.skip")
-            img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask")
-            res_down = self.ts.split_and_find([self.fate], img_down, mode="bless")
-            if res_up[1] == 2:
-                key_mouse_manager.click(*self.calc_point((0.5047, 0.5491), res_up[0]))
-                key_mouse_manager.wait()
-                chose = 1
-            elif res_down[1] == 2:
-                key_mouse_manager.click(*self.calc_point((0.5042, 0.3204), res_down[0]))
-                key_mouse_manager.wait()
-                chose = 1
-            if not chose:
-                key_mouse_manager.click(0.2990, 0.1046)
-                key_mouse_manager.wait()
-        # 未匹配到优先祝福，刷新祝福并再次匹配
-        if not chose:
-            for _ in range(4):
-                img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask", fresh=True)
-                if self.ts.split_and_find(self.tk.fates, img_down)[1] or self._stop:
-                    break
-                CUS_LOGGER.debug("未识别到命途")
-                if not self.click_text(text="选择祝福",box=[60, 222, 0, 113],click=False,ocr_line=False,warning=False):
-                    return 1
-            img_up = self.get_small_interaction_img(x=0.5047, y=0.5491, mask="mask_bless", fresh=True)
-            res_up = self.ts.split_and_find(self.tk.prior_bless, img_up, bless_skip=self.tk.skip)
-            img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask")
-            res_down = self.ts.split_and_find(self.tk.secondary, img_down, mode="bless")
-            if res_up[1] == 2:
-                CUS_LOGGER.debug("识别到具体祝福")
-                key_mouse_manager.click(*self.calc_point((0.5047, 0.5491), res_up[0]))
-                key_mouse_manager.wait()
-            elif res_down[1] >= 2:
-                CUS_LOGGER.debug("识别到匹配命途")
-                key_mouse_manager.click(*self.calc_point((0.5042, 0.3204), res_down[0]))
-                key_mouse_manager.wait()
-            elif self.click_text(text="选择祝福",box=[60, 222, 0, 113],click=False,ocr_line=False,warning=False,allow_fail=True):
-                CUS_LOGGER.debug("未识别到具体祝福,随便选一个")
-                key_mouse_manager.click(*self.calc_point((0.5047, 0.5491), res_up[0]))
-                key_mouse_manager.wait()
+        for _ in range(4):
+            img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask", fresh=True)
+            if self.ts.split_and_find(self.tk.fates, img_down)[1] or self._stop:
+                break
+            CUS_LOGGER.debug("未识别到命途")
+            if not self.click_text(text="选择祝福",box=[60, 222, 0, 113],click=False,ocr_line=False,warning=False):
+                 return 1
+        img_up = self.get_small_interaction_img(x=0.5047, y=0.5491, mask="mask_bless", fresh=True)
+        res_up = self.ts.split_and_find(self.tk.prior_bless, img_up, bless_skip=self.tk.skip)
+        img_down = self.get_small_interaction_img(x=0.5042, y=0.3204, mask="mask")
+        res_down = self.ts.split_and_find(self.tk.secondary, img_down, mode="bless")
+        if res_up[1] == 2:
+            CUS_LOGGER.debug("识别到具体祝福")
+            key_mouse_manager.click(*self.calc_point((0.5047, 0.5491), res_up[0]))
+            key_mouse_manager.wait()
+        elif res_down[1] >= 2:
+            CUS_LOGGER.debug("识别到匹配命途")
+            key_mouse_manager.click(*self.calc_point((0.5042, 0.3204), res_down[0]))
+            key_mouse_manager.wait()
+        elif self.click_text(text="选择祝福",box=[60, 222, 0, 113],click=False,ocr_line=False,warning=False,allow_fail=True):
+            CUS_LOGGER.debug("未识别到具体祝福,随便选一个")
+            key_mouse_manager.click(*self.calc_point((0.5047, 0.5491)))
+            key_mouse_manager.wait()
         self.click_text(text="确认",box=[1663, 1719, 949, 979],need_fresh=False,ocr_line=True,warning=True)
         key_mouse_manager.wait()
         if self.quan:


### PR DESCRIPTION
本 PR 删除了 `choose_bless()` 中的重置祝福逻辑。

### 修改内容

* 删除“重置祝福”相关流程
* 保留原有祝福优先级识别逻辑
* 直接从当前祝福中进行选择

### 修改原因

重置祝福会显著增加运行时间。

对于高效率刷取场景，
直接选择当前祝福会更高效、更稳定。
