### PR TITLE
新增月卡列车补给自动领取功能，新增每周积分处理功能

### DIFF
--- a/actions/insect.json
+++ b/actions/insect.json
@@ -773,5 +773,19 @@
         [
             "is_run"
         ]
+    },
+    {
+        "name": "列车补给",
+        "trigger": {
+            "text": "列车补给",
+            "box": [880, 1039, 55, 97],
+            "interval": 2,
+            "redundancy": 5
+        },
+        "actions": [
+            {
+                "position": [1200, 1000]
+            }
+        ]
     }
 ]

--- a/actions/insect.json
+++ b/actions/insect.json
@@ -536,6 +536,21 @@
         ]
     },
     {
+        "name": "月卡",
+        "trigger":{
+            "text": "列车补给",
+            "box": [880, 1039, 55, 97],
+            "interval": 2,
+            "redundancy": 30
+        },
+        "actions":
+        [
+            {
+                "position": [900, 1000]
+            }
+        ]
+    },
+    {
         "name": "备战开始",
         "trigger":{
             "text": "推荐信息",
@@ -742,12 +757,25 @@
         "name": "关闭积分奖励",
         "trigger":{
             "text": "积分奖励",
-            "box": [119, 253, 271, 308],
+            "box": [77, 192, 327, 359],
             "redundancy": 30
         },
         "actions":
         [   {
                 "press": "esc"
+            }
+        ]
+    },
+    {
+        "name": "积分线已更新",
+        "trigger":{
+            "text": "积分线已更新",
+            "box": [871, 1043, 521, 554],
+            "redundancy": 30
+        },
+        "actions":
+        [   {
+                "position": [900, 1000]
             }
         ]
     },
@@ -772,20 +800,6 @@
         "actions":
         [
             "is_run"
-        ]
-    },
-    {
-        "name": "列车补给",
-        "trigger": {
-            "text": "列车补给",
-            "box": [880, 1039, 55, 97],
-            "interval": 2,
-            "redundancy": 5
-        },
-        "actions": [
-            {
-                "position": [1200, 1000]
-            }
         ]
     }
 ]


### PR DESCRIPTION
新增了“月卡列车补给”自动领取功能，解决当前版本在凌晨四点月卡弹出时无法自动点击的问题。

### 修改内容

* 新增 trigger 检测“列车补给”文字
* 新增 action 点击领取位置
* 设置合理的 `interval` 与 `redundancy` 确保不会重复触发

### 修改效果

* 自动点击月卡领取界面
* 兼容奖励界面弹出后的继续点击
* 无需人工干预，保证月卡每日奖励可以顺利领取
* 保持原有状态驱动架构，非阻塞、事件驱动