### PR TITLE
fix: angle calibration multiplier gets incorrectly truncated, causing under-rotation

### DIFF
--- a/align_angle.py
+++ b/align_angle.py
@@ -62,7 +62,8 @@ def main(ang=[1,1,3], su=None):
         key_mouse_manager.multi *= ax / ay
     key_mouse_manager.multi += 1e-9
     try:
-        if abs(key_mouse_manager.multi) > 2:
+        if abs(key_mouse_manager.multi) > 10 or key_mouse_manager.multi <= 0:
+            CUS_LOGGER.warning(f"校准结果{key_mouse_manager.multi}超出合理范围，重置为默认值1")
             key_mouse_manager.multi = 1
     except:
         key_mouse_manager.multi = 1

--- a/align_angle.py
+++ b/align_angle.py
@@ -62,7 +62,7 @@ def main(ang=[1,1,3], su=None):
         key_mouse_manager.multi *= ax / ay
     key_mouse_manager.multi += 1e-9
     try:
-        if abs(key_mouse_manager.multi) > 10 or key_mouse_manager.multi <= 0:
+        if abs(key_mouse_manager.multi) > 5 or key_mouse_manager.multi <= 0:
             CUS_LOGGER.warning(f"校准结果{key_mouse_manager.multi}超出合理范围，重置为默认值1")
             key_mouse_manager.multi = 1
     except:

--- a/tool/simul/config.py
+++ b/tool/simul/config.py
@@ -39,13 +39,10 @@ class Config:
     @property
     def multi(self) -> float:
         x = float(self.angle)
-        if x > 5:
+        if x > 10 or x <= 0:
             self.angle = '1.0'
             return 1.0
-        elif x > 2:
-            return x - 2
-        else:
-            return x
+        return x
 
     @property
     def order(self) -> List[int]:

--- a/tool/simul/config.py
+++ b/tool/simul/config.py
@@ -39,7 +39,7 @@ class Config:
     @property
     def multi(self) -> float:
         x = float(self.angle)
-        if x > 10 or x <= 0:
+        if x > 5 or x <= 0:
             self.angle = '1.0'
             return 1.0
         return x


### PR DESCRIPTION
## Problem

On setups with lower mouse sensitivity, the multiplier computed by `align_angle.py`'s calibration routine often ends up in the 2–5 range. In that case two separate checks kick in and corrupt the final value that actually gets used:

1. In `align_angle.py`, `abs(multi) > 2` resets the multiplier straight to the default `1`, discarding a correctly-computed calibration result.
2. Even if that check is bypassed, the `multi` property in `tool/simul/config.py` executes `x - 2` for any value in `(2, 5]`, turning a correct value (e.g. 2.05) into a badly wrong one (0.05).
