### PR TITLE
fix: star history chart is broken, switch to a working provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ F5/‘停止任务’按钮停止运行。
 您的支持就是作者开发和维护项目的动力！
 
 ### And 每一位点star支持的你：
-[![Star History](https://api.star-history.com/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.com/#syfoud/Simulated_Scepter&Date)
+[![Star History](https://star-history.dera.page/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.dera.page/#syfoud/Simulated_Scepter&Date)

--- a/README_CHT.md
+++ b/README_CHT.md
@@ -203,4 +203,4 @@ F5/『停止任務』按鈕停止運行。
 您的支持就是作者開發和維護專案的動力！
 
 ### 每一位點star支持的你：
-[![Star History](https://api.star-history.com/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.com/#syfoud/Simulated_Scepter&Date)
+[![Star History](https://star-history.dera.page/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.dera.page/#syfoud/Simulated_Scepter&Date)

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -203,4 +203,4 @@ Thanks to the following contributors for their contributions to this project:
 Your support is the driving force behind the author's development and maintenance of this project!
 
 ### And every user who starred this project:
-[![Star History](https://api.star-history.com/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.com/#syfoud/Simulated_Scepter&Date)
+[![Star History](https://star-history.dera.page/svg?repos=syfoud/Simulated_Scepter&type=Date)](https://star-history.dera.page/#syfoud/Simulated_Scepter&Date)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so it renders correctly again, keeping the same repo and date parameters.