### PR TITLE
fix: 冒险关奖励箱交互后不再暂离，直接寻找觐见装置 (#83)

### DIFF
--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -2285,16 +2285,23 @@ class UniverseUtils:
                     key_mouse_manager.press('f')
                     key_mouse_manager.wait()
                     self.should_update_map = False
+                    first_visit = self.mini_state <= 1
                     if self.nof(must_be="challenge"):
                         CUS_LOGGER.info(f"最后一次，{factor}回想起那个朝阳初升的时刻，自己曾刻下理想的雏形…")
                         key_mouse_manager.keyUp("w")
-                        if self.is_run():
+                        if not self.is_run():
+                            break
+                        if first_visit:
+                            self.mini_state += 2
                             key_mouse_manager.press("esc")
                             key_mouse_manager.wait()
                             self.update_state("ui")
                             self.should_update_map = False
                             return
-                    break
+                        self.is_find_end = self.move_to_end(mode=2, device=1)
+                        if self.is_find_end:
+                            continue
+                        break
                 else:
                     CUS_LOGGER.info(f"{factor}为它取另外一个名字——「救世主」。而他自己的名，就此在记忆中零落。")
             if not self.is_run():


### PR DESCRIPTION
修复冒险奖励箱暂离问题，多次测试暂未发现会导致卡死的情况(毕竟本身就会自动往觐见装置移动)
#83
[log_2026-08-23-02-50.txt](https://github.com/user-attachments/files/31344624/log_2026-08-23-02-50.txt)