### PR TITLE
fix(currency): track nested bonus investment choices

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -12,6 +12,7 @@ from diver import load_actions, merge_text
 from route import PATHS
 from tool import EXTRA, GLOBAL
 from tool.currency.config import config
+from tool.currency.investment_state import InvestmentSelectionTracker, SelectionKind
 from tool.currency.text_key import text_keys
 from tool.currency.utils import CurrencyUtils, set_forground
 from tool.GLOBAL import factor, key_mouse_manager
@@ -23,13 +24,15 @@ from tool.utils.tool import get_hwnd_and_text
 
 class SimulatedCurrency(CurrencyUtils):
 
+    SPECIAL_INVESTMENTS = ("黄金投资", "白银投资")
+
     def __init__ (self, find, debug, speed, consumable, slow, nums = -1, bonus = False):
         super ().__init__ (speed)
         key_mouse_manager.set_config (config)
         # 设置屏幕参数以支持坐标转换
         key_mouse_manager.set_screen_params (self.x1, self.y1, self.xx, self.yy, self.full)
-        #第几次选择策略
-        self.select_bless_count = 0
+        # 普通位面选择、立即奖励和延迟奖励的状态
+        self.investment_tracker = InvestmentSelectionTracker()
         #停止运行标志
         self._stop = True
         #调试级别
@@ -53,7 +56,6 @@ class SimulatedCurrency(CurrencyUtils):
         self.max_refresh = 1
         #运行次数
         self.count = 0
-        self.bonus_rounds_remaining = 0  # 剩余奖励轮次数
         self.tk = text_keys ()
 
         self.ENVIR_BOXES = [[266, 610, 375, 413], [780, 1134, 375, 414], [1314, 1645, 373, 413]]
@@ -255,8 +257,7 @@ class SimulatedCurrency(CurrencyUtils):
             box=[1053, 1108, 967, 998],
             click=True,
         )
-        self.select_bless_count = 0
-        self.bonus_rounds_remaining = 0
+        self.investment_tracker.reset()
         time.sleep (0.1)
         CUS_LOGGER.info ("投资环境选择完成")
         return 1
@@ -274,12 +275,20 @@ class SimulatedCurrency(CurrencyUtils):
         return std > 10, std
 
     def select_bless (self):
-        """选择投资策略：第一次直接选中间，后续匹配必选'环保大使叽米'，否则选中间"""
+        """选择投资策略，并区分普通位面选择与黄金/白银投资奖励。"""
 
-        CUS_LOGGER.info(f"=== 第 {self.select_bless_count} 次进入 select_bless ===")
+        selection = self.investment_tracker.begin_selection()
+        kind_text = {
+            SelectionKind.NORMAL: "普通位面",
+            SelectionKind.IMMEDIATE_BONUS: "立即奖励",
+            SelectionKind.DELAYED_BONUS: "延迟奖励",
+        }[selection.kind]
+        CUS_LOGGER.info(
+            f"=== 进入投资策略选择：{kind_text}，"
+            f"已完成{self.investment_tracker.plane_count}面 ==="
+        )
         time.sleep (1)
         self.ts.forward (self.get_screen ())
-        # 三个选项的 box
         boxes = self.BLESS_BOXES
 
         centers = []
@@ -288,84 +297,76 @@ class SimulatedCurrency(CurrencyUtils):
             cy = (box[2] + box[3]) // 2
             centers.append((cx, cy))
 
-        if self.select_bless_count < self.exit_plane:
+        selected_idx = -1
+        texts = ["", "", ""]
+        roi_boxes = [
+            [617, 641, 219, 241],
+            [1116, 1141, 219, 241],
+            [1616, 1639, 219, 241],
+        ]
 
-            selected_idx = -1
+        for attempt in range (self.max_refresh + 1):
+            self.ts.forward (self.get_screen ())
+            texts = self.recognize_options (boxes)
+            CUS_LOGGER.info (f"OCR 识别结果: {texts}")
 
-            for attempt in range (self.max_refresh + 1):  # 0次正常识别 + 最多3次刷新后识别
-                self.ts.forward (self.get_screen ())
-                # ---- 调试：保存三个选项区域 ----
-                debug_dir = os.path.join(os.getcwd(), "temp")
-                os.makedirs(debug_dir, exist_ok=True)
-
-                # 三个选项的矩形区域（像素坐标）
-                roi_boxes = [
-                    [617, 641, 219, 241],
-                    [1116, 1141, 219, 241],
-                    [1616, 1639, 219, 241]
-                ]
-                target_centers = []
-                for box in roi_boxes:
-                    cx = (box[0] + box[1]) / 2 / self.xx
-                    cy = (box[2] + box[3]) / 2 / self.yy
-                    target_centers.append((cx, cy))
-
-                for idx, box in enumerate(roi_boxes):
-                    x1, x2, y1, y2 = box
-                    roi = self.screen[y1:y2, x1:x2]
-
-                    texts = self.recognize_options (self.BLESS_BOXES)
-                    CUS_LOGGER.info (f"OCR 识别结果: {texts}")
-
-                    # 调用标准差检测
-                    has_icon, std = self.detect_has_icon(roi)
-                    CUS_LOGGER.info(f"选项{idx+1} 是否有图标: {has_icon} (标准差: {std:.2f})")  # 如果需要打印具体值
-                    if has_icon:
-                        # 检测到图标 → 未解锁 → 选中它！
-                        selected_idx = idx
-                        CUS_LOGGER.info(f"第{attempt}次检测到未解锁图标，选中选项{idx+1}")
-                        break
-                if selected_idx != -1:
-                    if "黄金投资" in texts[selected_idx] or "白银投资" in texts[selected_idx]:
-                        self.bonus_rounds_remaining = 2  # 赠送 2 次选择
-                        CUS_LOGGER.info("检测到特殊投资，设置奖励轮次数: 2")
+            for idx, box in enumerate(roi_boxes):
+                x1, x2, y1, y2 = box
+                roi = self.screen[y1:y2, x1:x2]
+                has_icon, std = self.detect_has_icon(roi)
+                CUS_LOGGER.info(
+                    f"选项{idx+1} 是否有图标: {has_icon} (标准差: {std:.2f})"
+                )
+                if has_icon:
+                    selected_idx = idx
+                    CUS_LOGGER.info(
+                        f"第{attempt}次检测到未解锁图标，选中选项{idx+1}"
+                    )
                     break
 
-                # 如果没找到未解锁的，刷新...
-                if attempt < self.max_refresh:
-                    CUS_LOGGER.info(f"第 {attempt+1} 次未匹配，点击刷新")
-                    key_mouse_manager.click(384, 869)
-                    key_mouse_manager.click(868, 869)
-                    key_mouse_manager.click(1380, 869)
-                    time.sleep(1.5)
-                    self.ts.forward(self.get_screen())
-                else:
-                    # 刷新三次都没找到未解锁的 → 可能全部已解锁，随便选一个
-                    CUS_LOGGER.warning("刷新后仍未找到未解锁图标，默认选中间")
-                    selected_idx = 1
+            if selected_idx != -1:
+                break
 
-            # 点击选中的选项
+            if attempt < self.max_refresh:
+                CUS_LOGGER.info(f"第 {attempt+1} 次未匹配，点击刷新")
+                key_mouse_manager.click(384, 869)
+                key_mouse_manager.click(868, 869)
+                key_mouse_manager.click(1380, 869)
+                time.sleep(1.5)
+            else:
+                CUS_LOGGER.warning("刷新后仍未找到未解锁图标，默认选中间")
+                selected_idx = 1
 
+        selected_text = texts[selected_idx] if selected_idx < len(texts) else ""
+        special_investment = next(
+            (name for name in self.SPECIAL_INVESTMENTS if name in selected_text),
+            None,
+        )
+        if special_investment:
+            CUS_LOGGER.info(
+                f"检测到{special_investment}：登记1次立即奖励和下一边界1次延迟奖励"
+            )
 
-            key_mouse_manager.click (centers[selected_idx][0], centers[selected_idx][1])
-            time.sleep (0.1)
+        key_mouse_manager.click (centers[selected_idx][0], centers[selected_idx][1])
+        time.sleep (0.1)
 
-            # 点击确认
-            self.update_state ("escshop")
-            self.click_text (text = "确认", box = [948, 1005, 968, 999], click = True)
-            time.sleep (5)
-            CUS_LOGGER.info ("投资策略选择完成")
-            self.ts.forward (self.get_screen())
-        self.select_bless_count += 1
-        if self.bonus_rounds_remaining > 0:
-            self.select_bless_count -= 1
-            self.bonus_rounds_remaining -= 1
-            CUS_LOGGER.info(f"抵消一次特殊投资，剩余奖励次数: {self.bonus_rounds_remaining}")
+        self.update_state ("escshop")
+        self.click_text (text = "确认", box = [948, 1005, 968, 999], click = True)
+        time.sleep (5)
+        CUS_LOGGER.info ("投资策略选择完成")
+        self.ts.forward (self.get_screen())
 
+        self.investment_tracker.complete_selection(
+            selection,
+            grants_bonus=special_investment is not None,
+        )
+        CUS_LOGGER.info(
+            f"投资进度：普通位面={self.investment_tracker.plane_count}/"
+            f"{self.exit_plane}，立即奖励={self.investment_tracker.immediate_count}，"
+            f"延迟奖励={self.investment_tracker.delayed_count}"
+        )
 
-        CUS_LOGGER.info(f"比较: {self.select_bless_count} < {self.exit_plane} ? {self.select_bless_count < self.exit_plane}")
-
-        if self.select_bless_count >= self.exit_plane:
+        if self.investment_tracker.should_exit(self.exit_plane):
             CUS_LOGGER.info(f"达到退出位面（{self.exit_plane}面），按两次 ESC 退出当前对局，然后重开")
             self.update_state ("escshop")
             key_mouse_manager.press('esc') #关闭商店

--- a/test/test_currency_investment_state.py
+++ b/test/test_currency_investment_state.py
@@ -1,0 +1,134 @@
+import unittest
+
+from tool.currency.investment_state import (
+    InvestmentSelectionTracker,
+    SelectionKind,
+)
+
+
+class InvestmentSelectionTrackerTests(unittest.TestCase):
+    def complete(
+        self,
+        tracker: InvestmentSelectionTracker,
+        expected_kind: SelectionKind,
+        grants_bonus: bool = False,
+    ) -> None:
+        context = tracker.begin_selection()
+        self.assertEqual(expected_kind, context.kind)
+        tracker.complete_selection(context, grants_bonus=grants_bonus)
+
+    def test_first_plane_bonus_finishes_before_second_plane_exit(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.assertEqual(1, tracker.plane_count)
+        self.assertFalse(tracker.should_exit(2))
+
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+        self.complete(tracker, SelectionKind.DELAYED_BONUS)
+        self.complete(tracker, SelectionKind.NORMAL)
+
+        self.assertEqual(2, tracker.plane_count)
+        self.assertTrue(tracker.should_exit(2))
+
+    def test_bonus_from_delayed_choice_runs_after_second_normal_choice(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+
+        self.complete(tracker, SelectionKind.DELAYED_BONUS, grants_bonus=True)
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+
+        self.complete(tracker, SelectionKind.NORMAL)
+        self.assertEqual(2, tracker.plane_count)
+        self.assertEqual(1, tracker.delayed_count)
+        self.assertTrue(tracker.should_exit(2))
+        self.assertFalse(tracker.should_exit(3))
+
+        self.complete(tracker, SelectionKind.DELAYED_BONUS)
+        self.complete(tracker, SelectionKind.NORMAL)
+
+        self.assertEqual(3, tracker.plane_count)
+        self.assertTrue(tracker.should_exit(3))
+
+    def test_exit_plane_does_not_wait_for_future_delayed_bonus(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.assertFalse(tracker.should_exit(1))
+
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+
+        self.assertEqual(1, tracker.delayed_count)
+        self.assertTrue(tracker.should_exit(1))
+
+    def test_same_boundary_can_queue_multiple_delayed_bonuses(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.complete(
+            tracker,
+            SelectionKind.IMMEDIATE_BONUS,
+            grants_bonus=True,
+        )
+
+        self.assertEqual(1, tracker.immediate_count)
+        self.assertEqual(2, tracker.delayed_count)
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+
+        first_delayed = tracker.begin_selection()
+        self.assertEqual(SelectionKind.DELAYED_BONUS, first_delayed.kind)
+        tracker.complete_selection(first_delayed)
+
+        second_delayed = tracker.begin_selection()
+        self.assertEqual(SelectionKind.DELAYED_BONUS, second_delayed.kind)
+        self.assertEqual(first_delayed.boundary, second_delayed.boundary)
+        tracker.complete_selection(second_delayed)
+
+        self.assertEqual(SelectionKind.NORMAL, tracker.begin_selection().kind)
+
+    def test_nested_immediate_blocks_exit_until_chain_finishes(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.assertFalse(tracker.should_exit(1))
+
+        self.complete(
+            tracker,
+            SelectionKind.IMMEDIATE_BONUS,
+            grants_bonus=True,
+        )
+        self.assertEqual(1, tracker.plane_count)
+        self.assertEqual(1, tracker.immediate_count)
+        self.assertFalse(tracker.should_exit(1))
+
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+        self.assertTrue(tracker.should_exit(1))
+
+    def test_bonus_selections_never_increment_plane_count(self):
+        tracker = InvestmentSelectionTracker()
+
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+        self.assertEqual(1, tracker.plane_count)
+
+        self.complete(tracker, SelectionKind.IMMEDIATE_BONUS)
+        self.assertEqual(1, tracker.plane_count)
+
+        self.complete(tracker, SelectionKind.DELAYED_BONUS)
+        self.assertEqual(1, tracker.plane_count)
+
+    def test_reset_discards_previous_run_state(self):
+        tracker = InvestmentSelectionTracker()
+        self.complete(tracker, SelectionKind.NORMAL, grants_bonus=True)
+
+        tracker.reset()
+
+        self.assertEqual(0, tracker.plane_count)
+        self.assertEqual(0, tracker.immediate_count)
+        self.assertEqual(0, tracker.delayed_count)
+        self.assertEqual(SelectionKind.NORMAL, tracker.begin_selection().kind)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tool/currency/investment_state.py
+++ b/tool/currency/investment_state.py
@@ -1,0 +1,79 @@
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class SelectionKind(StrEnum):
+    NORMAL = "normal"
+    IMMEDIATE_BONUS = "immediate_bonus"
+    DELAYED_BONUS = "delayed_bonus"
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionContext:
+    kind: SelectionKind
+    boundary: int
+
+
+@dataclass(slots=True)
+class InvestmentSelectionTracker:
+    """Track normal and bonus investment choices across plane boundaries."""
+
+    plane_count: int = 0
+    _immediate_boundaries: deque[int] = field(default_factory=deque)
+    _delayed_by_boundary: Counter[int] = field(default_factory=Counter)
+
+    def reset(self) -> None:
+        self.plane_count = 0
+        self._immediate_boundaries.clear()
+        self._delayed_by_boundary.clear()
+
+    def begin_selection(self) -> SelectionContext:
+        if self._immediate_boundaries:
+            return SelectionContext(
+                SelectionKind.IMMEDIATE_BONUS,
+                self._immediate_boundaries[0],
+            )
+
+        boundary = self.plane_count
+        if self._delayed_by_boundary[boundary] > 0:
+            return SelectionContext(SelectionKind.DELAYED_BONUS, boundary)
+
+        return SelectionContext(SelectionKind.NORMAL, boundary)
+
+    def complete_selection(
+        self,
+        context: SelectionContext,
+        grants_bonus: bool = False,
+    ) -> None:
+        expected = self.begin_selection()
+        if context != expected:
+            raise RuntimeError(
+                f"Investment selection changed while processing: {context} != {expected}"
+            )
+
+        if context.kind == SelectionKind.IMMEDIATE_BONUS:
+            self._immediate_boundaries.popleft()
+        elif context.kind == SelectionKind.DELAYED_BONUS:
+            self._delayed_by_boundary[context.boundary] -= 1
+            if self._delayed_by_boundary[context.boundary] == 0:
+                del self._delayed_by_boundary[context.boundary]
+        else:
+            self.plane_count += 1
+
+        if grants_bonus:
+            self._immediate_boundaries.append(context.boundary)
+            self._delayed_by_boundary[context.boundary + 1] += 1
+
+    @property
+    def immediate_count(self) -> int:
+        return len(self._immediate_boundaries)
+
+    @property
+    def delayed_count(self) -> int:
+        return sum(self._delayed_by_boundary.values())
+
+    def should_exit(self, exit_plane: int) -> bool:
+        # Immediate choices block leaving the current screen. Delayed choices on a
+        # future boundary are intentionally abandoned when the requested plane ends.
+        return self.plane_count >= exit_plane and not self._immediate_boundaries


### PR DESCRIPTION
# PR 描述（建议分支 `fix/currency-investment-bonus-state`）

**标题**：`fix(currency): track nested bonus investment choices`

## 动机

货币战争通常可以用“投资策略选择次数”推断当前位面，但“黄金投资”和“白银投资”会额外触发：

- 当前节点立即进行一次额外三选一；
- 三个节点后、下一次普通位面投资前，再进行一次额外三选一；
- 额外选择仍可能再次选到黄金/白银投资，形成嵌套奖励链。

原逻辑使用单个 `bonus_rounds_remaining` 抵消后续选择次数，并在选中黄金/白银的同一次调用末尾立即消耗一次奖励。这样会把触发奖励的普通位面错误抵消，并把后续奖励选择计为普通位面；达到用户配置的退出位面时，程序可能在立即出现的三选一界面执行退出流程而卡住。

## 变更内容

- 新增 `tool/currency/investment_state.py`，按位面边界跟踪三类选择：
  - 普通位面选择；
  - 当前边界的立即奖励选择；
  - 下一边界、普通位面选择前的延迟奖励选择。
- 黄金/白银投资改为登记“1 次立即奖励 + 下一边界 1 次延迟奖励”，不再覆盖已有奖励；奖励选择再次触发黄金/白银时可继续递归排队。
- 普通位面计数只由普通选择递增，奖励选择不再污染退出位面计数。
- 达到配置退出位面后，先处理阻塞当前界面的立即奖励，再退出；未来边界尚未触发的延迟奖励不再阻止退出。
- 将黄金/白银判断移到最终选项确定之后，覆盖刷新耗尽后默认选择中间选项的路径。
- 每轮刷新只执行一次三个选项的 OCR，移除未使用的临时目录和坐标计算。

## 关键行为

- 第一面黄金、第二面退出：普通第一面 -> 立即奖励 -> 第一面后三节点延迟奖励 -> 普通第二面 -> 退出。
- 延迟奖励再次选到白银、第二面退出：处理白银的立即奖励和普通第二面后退出，不等待第二面之后才到期的延迟奖励。
- 延迟奖励再次选到白银、第三面退出：普通第二面后继续运行，在下一边界处理嵌套延迟奖励，再完成普通第三面并退出。
- 退出面自身选到黄金/白银：处理其立即奖励后退出，不为尚未到期的延迟奖励继续推进三个节点。

## 测试情况

- `python -m unittest discover -s test -p "test_currency_investment_state.py" -v` -> 7/7 通过
- `uvx ruff check currency.py tool\currency\investment_state.py test\test_currency_investment_state.py` -> 通过
- `uvx ruff format --check tool\currency\investment_state.py test\test_currency_investment_state.py` -> 通过
- `python -m compileall -q currency.py tool\currency\investment_state.py test\test_currency_investment_state.py` -> 通过
- `uvx ruff check . --exclude test --select=F821,E722,F403` -> 通过（与 CI lint 一致）
- `python -m compileall -q -x test .` -> 通过（与 CI compile-check 一致）
- `uv sync --frozen` 后执行 `uv run python -c "import new_gui; print('Startup import OK')"` -> 通过（与 Windows CI startup 一致）

## 验证说明

本 PR 已覆盖状态时序与递归奖励的单元测试，但尚未进行游戏内真机验证。真机审查时建议重点观察新增日志中的“普通位面 / 立即奖励 / 延迟奖励”分类和“投资进度”计数，并分别验证第二面、第三面退出路径。

## 提交前检查清单

- [x] 已同步上游 `master`，改动基于 `701b81f`
- [x] 已补充 Bug 回归测试并通过静态检查、编译检查和启动导入检查
- [x] 已遵循项目代码规范和 Conventional Commits 提交规范
- [x] PR 仅包含货币战争投资奖励状态修复及对应测试
- [ ] 项目维护者人工审查：等待通过本 PR 审查
- [ ] 游戏内真机验证：黄金/白银投资需从 340 余个策略中随机刷出，本次未完成

关联 Issue：无。
