### PR TITLE
fix(currency): handle chalice trial popup

### DIFF
--- a/actions/currencywar.json
+++ b/actions/currencywar.json
@@ -290,6 +290,27 @@
         ]
     },
     {
+        "name": "命运圣杯祈愿试炼",
+        "trigger":{
+            "text": "请选择一个祈愿试炼",
+            "box": [1400, 1595, 572, 599],
+            "interval": 2,
+            "redundancy": 30
+        },
+        "actions":
+        [
+            {
+                "position": [684, 398]
+            },
+            {
+                "sleep": 0.5
+            },
+            {
+                "position": [1495, 639]
+            }
+        ]
+    },
+    {
         "name": "独家代言",
         "trigger":{
             "text": "查看详情",

--- a/test/test_currencywar_actions.py
+++ b/test/test_currencywar_actions.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class CurrencyWarActionsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        config_path = Path(__file__).resolve().parents[1] / "actions" / "currencywar.json"
+        with config_path.open(encoding="utf-8") as config_file:
+            cls.actions = json.load(config_file)
+
+    def test_chalice_trial_popup_selects_left_trial_and_confirms(self):
+        matches = [
+            action
+            for action in self.actions
+            if action.get("name") == "命运圣杯祈愿试炼"
+        ]
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(
+            matches[0],
+            {
+                "name": "命运圣杯祈愿试炼",
+                "trigger": {
+                    "text": "请选择一个祈愿试炼",
+                    "box": [1400, 1595, 572, 599],
+                    "interval": 2,
+                    "redundancy": 30,
+                },
+                "actions": [
+                    {"position": [684, 398]},
+                    {"sleep": 0.5},
+                    {"position": [1495, 639]},
+                ],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

4.4 版本新增“命运圣杯”羁绊。上场满足条件的角色后，游戏会弹出祈愿试炼二选一界面；货币战争模块此前没有处理该弹窗，会阻塞后续流程。

## 变更内容

- 使用选择完成后会消失的固定文本 `请选择一个祈愿试炼` 识别弹窗，避免依赖随机试炼内容
- 固定选择左侧试炼，等待界面更新后点击“确认选择”
- 添加配置回归测试，固定触发文本、识别区域和点击顺序

## 测试情况

- [x] `.\.venv\Scripts\python.exe -m unittest test.test_currencywar_actions test.test_currency_investment_state`（8 项通过）
- [x] `.\.venv\Scripts\ruff.exe check test\test_currencywar_actions.py`
- [x] 使用货币模块自身 OCR 在当前游戏画面验证，规则精确命中目标文本
- [x] 人工实机验证：能够正确选择试炼并点击确认

## 关联 Issue

无。