### PR TITLE
fix(currency): preserve reincarnation resources

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -12,6 +12,7 @@ from diver import load_actions, merge_text
 from route import PATHS
 from tool import EXTRA, GLOBAL
 from tool.currency.config import config
+from tool.currency.investment_selection import choose_fallback_investment
 from tool.currency.investment_state import InvestmentSelectionTracker, SelectionKind
 from tool.currency.text_key import text_keys
 from tool.currency.utils import CurrencyUtils, set_forground
@@ -310,10 +311,12 @@ class SimulatedCurrency(CurrencyUtils):
             texts = self.recognize_options (boxes)
             CUS_LOGGER.info (f"OCR 识别结果: {texts}")
 
+            icon_presence = [False] * len(roi_boxes)
             for idx, box in enumerate(roi_boxes):
                 x1, x2, y1, y2 = box
                 roi = self.screen[y1:y2, x1:x2]
                 has_icon, std = self.detect_has_icon(roi)
+                icon_presence[idx] = has_icon
                 CUS_LOGGER.info(
                     f"选项{idx+1} 是否有图标: {has_icon} (标准差: {std:.2f})"
                 )
@@ -334,8 +337,13 @@ class SimulatedCurrency(CurrencyUtils):
                 key_mouse_manager.click(1380, 869)
                 time.sleep(1.5)
             else:
-                CUS_LOGGER.warning("刷新后仍未找到未解锁图标，默认选中间")
-                selected_idx = 1
+                selected_idx = choose_fallback_investment(texts, icon_presence)
+                if selected_idx == 1:
+                    CUS_LOGGER.warning("刷新后仍未找到未解锁图标，默认选中间")
+                else:
+                    CUS_LOGGER.warning(
+                        "中间选项为无图鉴图标的轮回不止，改选左侧以保留跨局资源"
+                    )
 
         selected_text = texts[selected_idx] if selected_idx < len(texts) else ""
         special_investment = next(

--- a/test/test_currency_investment_selection.py
+++ b/test/test_currency_investment_selection.py
@@ -1,0 +1,41 @@
+import unittest
+
+from tool.currency.investment_selection import choose_fallback_investment
+
+
+class InvestmentFallbackSelectionTests(unittest.TestCase):
+    def test_middle_reincarnation_with_icon_keeps_original_middle_choice(self):
+        selected = choose_fallback_investment(
+            ["普通投资甲", "轮回不止", "普通投资乙"],
+            [False, True, False],
+        )
+
+        self.assertEqual(selected, 1)
+
+    def test_middle_reincarnation_without_icon_uses_left_choice(self):
+        selected = choose_fallback_investment(
+            ["普通投资甲", "轮回不止", "普通投资乙"],
+            [False, False, False],
+        )
+
+        self.assertEqual(selected, 0)
+
+    def test_normal_middle_option_keeps_original_fallback(self):
+        selected = choose_fallback_investment(
+            ["普通投资甲", "普通投资乙", "普通投资丙"],
+            [False, False, False],
+        )
+
+        self.assertEqual(selected, 1)
+
+    def test_side_reincarnation_does_not_change_middle_fallback(self):
+        selected = choose_fallback_investment(
+            ["轮回不止", "普通投资甲", "普通投资乙"],
+            [False, False, False],
+        )
+
+        self.assertEqual(selected, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool/currency/investment_selection.py
+++ b/tool/currency/investment_selection.py
@@ -1,0 +1,26 @@
+from collections.abc import Sequence
+
+RESOURCE_INHERITANCE_INVESTMENT = "轮回不止"
+DEFAULT_INVESTMENT_INDEX = 1
+SAFE_SIDE_INDEX = 0
+
+
+def choose_fallback_investment(
+    texts: Sequence[str],
+    icon_presence: Sequence[bool],
+) -> int:
+    """Choose the default option without overwriting inherited resources."""
+    if len(texts) <= DEFAULT_INVESTMENT_INDEX:
+        return SAFE_SIDE_INDEX
+
+    middle_has_icon = (
+        len(icon_presence) > DEFAULT_INVESTMENT_INDEX
+        and icon_presence[DEFAULT_INVESTMENT_INDEX]
+    )
+    if (
+        not middle_has_icon
+        and RESOURCE_INHERITANCE_INVESTMENT in texts[DEFAULT_INVESTMENT_INDEX]
+    ):
+        return SAFE_SIDE_INDEX
+
+    return DEFAULT_INVESTMENT_INDEX


### PR DESCRIPTION
## 背景

投资策略“轮回不止”会跨局继承资源。现有逻辑在刷新耗尽且没有识别到图鉴图标时固定选择中间，可能在“轮回不止”位于中间且没有图鉴图标时覆盖用户积累的资源。

## 变更内容

- 保留原有图鉴图标优先选择逻辑
- 记录最终一轮三个选项的图标状态
- 仅当刷新耗尽、中间选项为无图鉴图标的“轮回不止”时改选左侧
- 其他无图标情况继续默认选择中间
- 增加纯选择策略和四类回归测试

## 测试情况

- [x] `.\.venv\Scripts\python.exe -m unittest test.test_currency_investment_selection test.test_currency_investment_state test.test_currencywar_actions`（12 项通过）
- [x] 新增文件完整 Ruff 检查
- [x] `currency.py` 按仓库 CI crash-level 规则检查
- [x] Python 编译检查
- [x] 货币战争模块维护者人工审查
- [ ] 实机命中验证：该策略来自 340 多项随机池，当前无法稳定复现；本 PR 先合入 `currency_dev` 验证，不影响 `master`

## 关联 Issue

无。