### PR TITLE
feat(currency): add GUI exit-plane setting

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -6,7 +6,6 @@ import time
 import cv2
 import numpy as np
 import pyautogui
-import yaml
 
 from diver import load_actions, merge_text
 from route import PATHS
@@ -14,6 +13,7 @@ from tool import EXTRA, GLOBAL
 from tool.currency.config import config
 from tool.currency.investment_selection import choose_fallback_investment
 from tool.currency.investment_state import InvestmentSelectionTracker, SelectionKind
+from tool.currency.settings import load_currency_settings
 from tool.currency.text_key import text_keys
 from tool.currency.utils import CurrencyUtils, set_forground
 from tool.GLOBAL import factor, key_mouse_manager
@@ -77,29 +77,9 @@ class SimulatedCurrency(CurrencyUtils):
             with open(settings_path, encoding="UTF-8") as file:
                 data = json.load(file)
 
-        # 读取货币战争专用配置
-        currency_config_file = PATHS["root"] + "\\config\\config\\currency_config.yml"
-        currency_example_file = PATHS["root"] + "\\config\\config\\currency_config_example.yml"
-        if not os.path.exists(currency_config_file):
-            if os.path.exists(currency_example_file):
-                shutil.copy2(currency_example_file, currency_config_file)
-            else:
-                # 如果示例文件也不存在，创建一个默认的
-                os.makedirs(os.path.dirname(currency_config_file), exist_ok=True)
-                with open(currency_config_file, "w", encoding="utf-8") as f:
-                    f.write("# 货币战争模块配置文件\n")
-                    f.write("# 在第几面结束后退出（默认第1面）\n")
-                    f.write("exit_after_plane: 1\n")
-
-        # 加载配置
-        try:
-            with open(currency_config_file, encoding="utf-8", errors="ignore") as f:
-                currency_config = yaml.safe_load(f) or {}
-                self.exit_plane = currency_config.get("exit_after_plane", 1)
-                CUS_LOGGER.info(f"货币战争退出位面设置为: 第{self.exit_plane}面")
-        except Exception as e:
-            CUS_LOGGER.warning(f"读取货币战争配置失败，使用默认退出位面1: {e}")
-            self.exit_plane = 1
+        currency_settings = load_currency_settings()
+        self.exit_plane = currency_settings["exit_after_plane"]
+        CUS_LOGGER.info(f"货币战争退出位面设置为: 第{self.exit_plane}面")
 
         self.record = data.get("recording_state", True)
 

--- a/load_ui.py
+++ b/load_ui.py
@@ -51,7 +51,7 @@ class QMainWindowLoadUI(QtWidgets.QMainWindow):
         self.font_set()
 
         self.run_diver_btn.setVisible(False)
-        self.tabWidget.setTabVisible(4, False)
+        self.tabWidget.setTabVisible(self.tabWidget.indexOf(self.Tab6), False)
         self.label_7.setVisible(False)
         self.Diver_debug_checkbox.setVisible(False)
         self.Simul_debug_checkbox.setVisible(False)

--- a/new_gui.py
+++ b/new_gui.py
@@ -14,6 +14,11 @@ from tool.countdown_config import (
     DECISION_MODES, MC_SETTING_FIELDS, load_finger_snap_settings,
     save_finger_snap_settings,
 )
+from tool.currency.settings import (
+    EXIT_PLANES,
+    load_currency_settings,
+    save_currency_settings,
+)
 from tool.log import log_emitter
 from tool.thread import ThreadWithException
 from tool.utils.image_tool import find_image_by_name, load_all_images_from_directory
@@ -182,8 +187,18 @@ class MainWindow(QMainWindowLog):
         self.Diver_timezone_combo.setCurrentText(config_diver.timezone)
         self.Diver_max_run_input = QLineEdit(str(config_diver.max_run))
 
+        # 初始化货币战争配置界面
+        currency_settings = load_currency_settings()
+        for exit_plane in EXIT_PLANES:
+            self.Currency_exit_plane_combo.addItem(f"第 {exit_plane} 位面", exit_plane)
+        exit_plane_index = self.Currency_exit_plane_combo.findData(
+            currency_settings["exit_after_plane"]
+        )
+        self.Currency_exit_plane_combo.setCurrentIndex(exit_plane_index)
+
         # 连接配置保存按钮
         self.config_save_btn.clicked.connect(self.save_config)
+        self.Currency_save_btn.clicked.connect(self.save_currency_config)
         self.Iron_blood_save_btn.clicked.connect(self.save_iron_config)
         self.Finger_snap_save_btn.clicked.connect(self.save_finger_snap_config)
         self.Aboutupdatelock.clicked.connect(self.show_unlock_dialog)
@@ -657,6 +672,17 @@ class MainWindow(QMainWindowLog):
         self.save_ui_settings()
 
         QMessageBox.information(self, "提示", "配置已保存")
+
+    def save_currency_config(self):
+        try:
+            save_currency_settings(
+                {"exit_after_plane": self.Currency_exit_plane_combo.currentData()}
+            )
+        except OSError as error:
+            QMessageBox.critical(self, "错误", f"货币战争配置保存失败：{error}")
+            return
+        QMessageBox.information(self, "提示", "货币战争配置已保存")
+
     def save_iron_config(self):
         self.save_ui_settings()
         QMessageBox.information(self, "提示", "配置已保存")

--- a/resource/ui/UI.ui
+++ b/resource/ui/UI.ui
@@ -1085,6 +1085,113 @@ border:none</string>
              </item>
             </layout>
            </item>
+         </layout>
+         </widget>
+         <widget class="QWidget" name="CurrencyWarTab">
+          <attribute name="title">
+           <string>货币战争设置</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_currency_war">
+           <property name="spacing">
+            <number>5</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>10</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="Currency_settings_label">
+             <property name="text">
+              <string>货币战争设置</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_currency_exit_plane">
+             <item>
+              <widget class="QLabel" name="Currency_exit_plane_label">
+               <property name="text">
+                <string>退出位面：</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="Currency_exit_plane_combo">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>180</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>240</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_currency_exit_plane">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QPushButton" name="Currency_save_btn">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>240</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>保存</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_currency_war">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="AbyssTab">

--- a/test/test_currency_gui_ui.py
+++ b/test/test_currency_gui_ui.py
@@ -1,0 +1,33 @@
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+UI_PATH = Path(__file__).resolve().parents[1] / "resource" / "ui" / "UI.ui"
+
+
+class CurrencyGuiUiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.root = ET.parse(UI_PATH).getroot()
+
+    def test_currency_settings_has_dedicated_tab(self):
+        tab = self.root.find(".//widget[@name='CurrencyWarTab']")
+
+        self.assertIsNotNone(tab)
+        self.assertEqual(tab.find("./attribute[@name='title']/string").text, "货币战争设置")
+
+    def test_currency_settings_uses_choice_and_save_controls(self):
+        tab = self.root.find(".//widget[@name='CurrencyWarTab']")
+
+        self.assertIsNotNone(
+            tab.find(".//widget[@class='QComboBox'][@name='Currency_exit_plane_combo']")
+        )
+        save_button = tab.find(
+            ".//widget[@class='QPushButton'][@name='Currency_save_btn']"
+        )
+        self.assertIsNotNone(save_button)
+        self.assertEqual(save_button.find("./property[@name='text']/string").text, "保存")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_currency_settings.py
+++ b/test/test_currency_settings.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from tool.currency.settings import (
+    DEFAULT_EXIT_PLANE,
+    EXIT_PLANES,
+    load_currency_settings,
+    save_currency_settings,
+)
+
+
+class CurrencySettingsTests(unittest.TestCase):
+    def test_exit_plane_choices_are_fixed(self):
+        self.assertEqual(EXIT_PLANES, (1, 2, 3))
+
+    def test_missing_config_uses_first_plane(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = load_currency_settings(Path(temp_dir) / "missing.yml")
+
+        self.assertEqual(settings["exit_after_plane"], DEFAULT_EXIT_PLANE)
+
+    def test_loads_supported_exit_plane(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "currency.yml"
+            path.write_text("exit_after_plane: 3\n", encoding="utf-8")
+
+            settings = load_currency_settings(path)
+
+        self.assertEqual(settings["exit_after_plane"], 3)
+
+    def test_invalid_exit_plane_falls_back_to_first_plane(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "currency.yml"
+            path.write_text("exit_after_plane: 9\n", encoding="utf-8")
+
+            settings = load_currency_settings(path)
+
+        self.assertEqual(settings["exit_after_plane"], DEFAULT_EXIT_PLANE)
+
+    def test_save_preserves_other_currency_settings(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "currency.yml"
+            path.write_text("future_setting: true\n", encoding="utf-8")
+
+            saved = save_currency_settings({"exit_after_plane": 2}, path)
+            values = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(saved["exit_after_plane"], 2)
+        self.assertEqual(values, {"future_setting": True, "exit_after_plane": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool/currency/settings.py
+++ b/tool/currency/settings.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+
+import yaml
+
+from route import PATHS
+from tool import EXTRA
+
+EXIT_PLANES = (1, 2, 3)
+DEFAULT_EXIT_PLANE = 1
+CONFIG_PATH = Path(PATHS["root"]) / "config" / "config" / "currency_config.yml"
+EXAMPLE_PATH = CONFIG_PATH.with_name("currency_config_example.yml")
+
+
+def normalize_currency_settings(values=None):
+    """Validate currency-war settings and return serializable values."""
+    values = values if isinstance(values, dict) else {}
+    try:
+        exit_plane = int(values.get("exit_after_plane", DEFAULT_EXIT_PLANE))
+    except (TypeError, ValueError):
+        exit_plane = DEFAULT_EXIT_PLANE
+    if exit_plane not in EXIT_PLANES:
+        exit_plane = DEFAULT_EXIT_PLANE
+    return {"exit_after_plane": exit_plane}
+
+
+def load_currency_settings(path=CONFIG_PATH):
+    """Load the currency-war settings, falling back to safe defaults."""
+    path = Path(path)
+    if not path.exists() and path == CONFIG_PATH and EXAMPLE_PATH.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(EXAMPLE_PATH, path)
+    if not path.exists():
+        return normalize_currency_settings()
+
+    with EXTRA.FILE_LOCK:
+        try:
+            with path.open(encoding="utf-8") as config_file:
+                values = yaml.safe_load(config_file) or {}
+        except (OSError, yaml.YAMLError):
+            values = {}
+    return normalize_currency_settings(values)
+
+
+def save_currency_settings(values, path=CONFIG_PATH):
+    """Update currency-war settings while preserving future config fields."""
+    path = Path(path)
+    normalized = normalize_currency_settings(values)
+    with EXTRA.FILE_LOCK:
+        try:
+            current = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            current = {}
+        if not isinstance(current, dict):
+            current = {}
+        current.update(normalized)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(current, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+    return normalized


### PR DESCRIPTION
## 背景

货币战争的退出位面目前只能通过手动修改 `currency_config.yml` 设置。用户需要在 GUI 中直接选择固定的第 1/2/3 位面退出。

## 变更内容

- 新增独立“货币战争设置”标签页
- 使用固定三项下拉选择器，避免自由输入非法位面
- 增加货币战争共享配置读写模块，GUI 和运行逻辑读取同一份 `currency_config.yml`
- 保存时校验退出位面并保留未来新增的配置字段
- 按控件对象隐藏性能分析页，避免新增标签后数字索引失效
- 增加配置读写和 UI 结构回归测试

## 测试情况

- [x] 19 项货币战争相关单元测试通过
- [x] 新增配置与 UI 测试完整 Ruff 检查
- [x] 修改的现有模块通过仓库 CI crash-level Ruff 规则
- [x] Python 编译检查
- [x] 真实 `MainWindow` 离屏初始化：下拉项数据为整数 `[1, 2, 3]`
- [x] 模拟选择第 3 位面后，保存槽向配置层传递 `exit_after_plane: 3`
- [x] 960×760 主题化离屏截图人工检查：标签、选择器和保存按钮无重叠

## 关联 Issue

无。