### PR TITLE
feat(currency): record run history

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -13,6 +13,12 @@ from tool import EXTRA, GLOBAL
 from tool.currency.config import config
 from tool.currency.investment_selection import choose_fallback_investment
 from tool.currency.investment_state import InvestmentSelectionTracker, SelectionKind
+from tool.currency.run_history import (
+    RUN_END_ACTION,
+    RUN_START_ACTION,
+    CurrencyRunHistory,
+    get_newly_unlocked_investment,
+)
 from tool.currency.settings import load_currency_settings
 from tool.currency.text_key import text_keys
 from tool.currency.utils import CurrencyUtils, set_forground
@@ -34,6 +40,7 @@ class SimulatedCurrency(CurrencyUtils):
         key_mouse_manager.set_screen_params (self.x1, self.y1, self.xx, self.yy, self.full)
         # 普通位面选择、立即奖励和延迟奖励的状态
         self.investment_tracker = InvestmentSelectionTracker()
+        self.run_history = CurrencyRunHistory()
         #停止运行标志
         self._stop = True
         #调试级别
@@ -326,6 +333,11 @@ class SimulatedCurrency(CurrencyUtils):
                     )
 
         selected_text = texts[selected_idx] if selected_idx < len(texts) else ""
+        unlocked_investment = get_newly_unlocked_investment(
+            texts,
+            icon_presence,
+            selected_idx,
+        )
         special_investment = next(
             (name for name in self.SPECIAL_INVESTMENTS if name in selected_text),
             None,
@@ -348,6 +360,11 @@ class SimulatedCurrency(CurrencyUtils):
             selection,
             grants_bonus=special_investment is not None,
         )
+        if (
+            unlocked_investment
+            and self.run_history.record_unlocked_investment(unlocked_investment)
+        ):
+            CUS_LOGGER.info(f"本局新解锁投资策略：{unlocked_investment}")
         CUS_LOGGER.info(
             f"投资进度：普通位面={self.investment_tracker.plane_count}/"
             f"{self.exit_plane}，立即奖励={self.investment_tracker.immediate_count}，"
@@ -429,6 +446,7 @@ class SimulatedCurrency(CurrencyUtils):
                                 return i['name'], 1
                         for j in i["actions"]:
                             self.do_action(j)
+                        self._on_static_action_completed(i["name"])
                         self.action_history.append(i["name"])
                         #记录最近10个动作
                         self.action_history = self.action_history[-10:]
@@ -450,6 +468,7 @@ class SimulatedCurrency(CurrencyUtils):
                                 for j in i["actions"]:
                                     re=self.do_action(j)
                                 resu=re if re is not None else resu
+                                self._on_static_action_completed(i["name"])
                                 self.action_history.append(i["name"])
                                 #记录最近10个动作
                                 self.action_history = self.action_history[-10:]
@@ -468,6 +487,7 @@ class SimulatedCurrency(CurrencyUtils):
                                 for j in i["actions"]:
                                     re=self.do_action(j)
                                 resu=re if re is not None else resu
+                                self._on_static_action_completed(i["name"])
                                 self.action_history.append(i["name"])
                                 #记录最近10个动作
                                 self.action_history = self.action_history[-10:]
@@ -475,6 +495,26 @@ class SimulatedCurrency(CurrencyUtils):
                                 #返回触发的名字
                                 return i['name'],resu
         return '',0
+
+    def _on_static_action_completed(self, action_name: str) -> None:
+        if action_name == RUN_START_ACTION:
+            self.run_history.start_run()
+            CUS_LOGGER.info("货币战争对局计时开始")
+            return
+
+        if action_name != RUN_END_ACTION:
+            return
+
+        try:
+            record = self.run_history.finish_run()
+        except OSError as error:
+            CUS_LOGGER.error(f"货币战争对局记录写入失败：{error}")
+            return
+
+        if record is None:
+            CUS_LOGGER.warning("未找到本局开始记录，跳过货币战争对局统计")
+        else:
+            CUS_LOGGER.info(f"货币战争对局记录完成：{record}")
 
     def do_action(self, action) -> int:
         """

--- a/test/test_currency_run_history.py
+++ b/test/test_currency_run_history.py
@@ -1,0 +1,127 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tool.currency.run_history import (
+    CurrencyRunHistory,
+    get_newly_unlocked_investment,
+)
+
+
+class FakeClock:
+    def __init__(self, current: float = 0):
+        self.current = current
+
+    def __call__(self) -> float:
+        return self.current
+
+
+class CurrencyRunHistoryTests(unittest.TestCase):
+    def create_history(self, directory: str, clock: FakeClock) -> CurrencyRunHistory:
+        return CurrencyRunHistory(Path(directory) / "currency_count.txt", clock)
+
+    def test_writes_unlocked_investments_and_elapsed_time(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clock = FakeClock(100)
+            history = self.create_history(temp_dir, clock)
+
+            history.start_run()
+            self.assertTrue(history.record_unlocked_investment("投资策略甲"))
+            self.assertTrue(history.record_unlocked_investment("投资策略乙"))
+            self.assertFalse(history.record_unlocked_investment("投资策略甲"))
+            clock.current = 225
+
+            record = history.finish_run()
+
+            self.assertEqual(
+                record,
+                "对局次数：1，本局解锁的投资策略：投资策略甲、投资策略乙，用时：2分5秒",
+            )
+            self.assertEqual(
+                (Path(temp_dir) / "currency_count.txt").read_text(encoding="utf-8"),
+                record + "\n",
+            )
+
+    def test_writes_none_when_no_investment_was_unlocked(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clock = FakeClock(10)
+            history = self.create_history(temp_dir, clock)
+            history.start_run()
+            clock.current = 11
+
+            record = history.finish_run()
+
+            self.assertEqual(
+                record,
+                "对局次数：1，本局解锁的投资策略：无，用时：0分1秒",
+            )
+
+    def test_continues_from_largest_persisted_run_count(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "currency_count.txt"
+            path.write_text(
+                "对局次数：2，本局解锁的投资策略：无，用时：1分0秒\n"
+                "无法识别的旧记录\n"
+                "对局次数:5, 本局解锁的投资策略:无, 用时:2分0秒\n",
+                encoding="utf-8",
+            )
+            clock = FakeClock()
+            history = CurrencyRunHistory(path, clock)
+            history.start_run()
+
+            record = history.finish_run()
+
+            self.assertTrue(record.startswith("对局次数：6，"))
+
+    def test_new_start_discards_an_unfinished_run(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clock = FakeClock(10)
+            history = self.create_history(temp_dir, clock)
+            history.start_run()
+            history.record_unlocked_investment("投资策略甲")
+            clock.current = 40
+
+            history.start_run()
+            clock.current = 70
+            record = history.finish_run()
+
+            self.assertIn("本局解锁的投资策略：无", record)
+            self.assertTrue(record.endswith("用时：0分30秒"))
+
+    def test_ignores_unlock_and_finish_before_run_starts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clock = FakeClock()
+            history = self.create_history(temp_dir, clock)
+
+            self.assertFalse(history.record_unlocked_investment("投资策略甲"))
+            self.assertIsNone(history.finish_run())
+            self.assertFalse((Path(temp_dir) / "currency_count.txt").exists())
+
+
+class NewlyUnlockedInvestmentTests(unittest.TestCase):
+    def test_returns_selected_text_when_icon_is_present(self):
+        self.assertEqual(
+            get_newly_unlocked_investment(
+                ["投资策略甲", "投资策略乙", "投资策略丙"],
+                [False, True, False],
+                1,
+            ),
+            "投资策略乙",
+        )
+
+    def test_ignores_selected_text_without_icon(self):
+        self.assertIsNone(
+            get_newly_unlocked_investment(
+                ["投资策略甲", "投资策略乙", "投资策略丙"],
+                [False, False, False],
+                1,
+            )
+        )
+
+    def test_ignores_invalid_or_blank_selection(self):
+        self.assertIsNone(get_newly_unlocked_investment(["投资策略甲"], [True], -1))
+        self.assertIsNone(get_newly_unlocked_investment([""], [True], 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_currencywar_actions.py
+++ b/test/test_currencywar_actions.py
@@ -2,6 +2,8 @@ import json
 import unittest
 from pathlib import Path
 
+from tool.currency.run_history import RUN_END_ACTION, RUN_START_ACTION
+
 
 class CurrencyWarActionsTest(unittest.TestCase):
     @classmethod
@@ -35,6 +37,12 @@ class CurrencyWarActionsTest(unittest.TestCase):
                 ],
             },
         )
+
+    def test_run_history_actions_keep_expected_names(self):
+        action_names = {action.get("name") for action in self.actions}
+
+        self.assertIn(RUN_START_ACTION, action_names)
+        self.assertIn(RUN_END_ACTION, action_names)
 
 
 if __name__ == "__main__":

--- a/tool/currency/run_history.py
+++ b/tool/currency/run_history.py
@@ -1,0 +1,87 @@
+import re
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from route import PATHS
+from tool import EXTRA
+
+RUN_START_ACTION = "选择难度后开始对局"
+RUN_END_ACTION = "重开最终"
+DEFAULT_RECORD_PATH = Path(PATHS["root"]) / "config" / "backup" / "currency_count.txt"
+_COUNT_PATTERN = re.compile(r"对局次数\s*[：:]\s*(\d+)")
+
+
+def get_newly_unlocked_investment(
+    texts: Sequence[str],
+    icon_presence: Sequence[bool],
+    selected_index: int,
+) -> str | None:
+    """Return the selected investment only when its compendium icon is present."""
+    if not 0 <= selected_index < len(texts) or selected_index >= len(icon_presence):
+        return None
+    if not icon_presence[selected_index]:
+        return None
+
+    text = texts[selected_index].strip()
+    return text or None
+
+
+@dataclass
+class CurrencyRunHistory:
+    record_path: Path = DEFAULT_RECORD_PATH
+    clock: Callable[[], float] = time.time
+    _started_at: float | None = field(default=None, init=False)
+    _unlocked_investments: list[str] = field(default_factory=list, init=False)
+
+    @property
+    def is_active(self) -> bool:
+        return self._started_at is not None
+
+    def start_run(self) -> None:
+        self._started_at = self.clock()
+        self._unlocked_investments.clear()
+
+    def record_unlocked_investment(self, investment: str) -> bool:
+        investment = investment.strip()
+        if not self.is_active or not investment or investment in self._unlocked_investments:
+            return False
+
+        self._unlocked_investments.append(investment)
+        return True
+
+    def finish_run(self) -> str | None:
+        if self._started_at is None:
+            return None
+
+        elapsed = max(0, int(self.clock() - self._started_at))
+        investments = "、".join(self._unlocked_investments) or "无"
+
+        try:
+            with EXTRA.FILE_LOCK:
+                run_count = self._read_last_run_count() + 1
+                record = (
+                    f"对局次数：{run_count}，本局解锁的投资策略：{investments}，"
+                    f"用时：{elapsed // 60}分{elapsed % 60}秒"
+                )
+                self.record_path.parent.mkdir(parents=True, exist_ok=True)
+                with self.record_path.open("a", encoding="utf-8") as file:
+                    file.write(record + "\n")
+        finally:
+            self._started_at = None
+            self._unlocked_investments.clear()
+
+        return record
+
+    def _read_last_run_count(self) -> int:
+        if not self.record_path.exists():
+            return 0
+
+        last_count = 0
+        with self.record_path.open(encoding="utf-8", errors="replace") as file:
+            for line in file:
+                match = _COUNT_PATTERN.search(line)
+                if match:
+                    last_count = max(last_count, int(match.group(1)))
+        return last_count


### PR DESCRIPTION
## 背景

铁血战士模块已有轮回次数、击杀数和用时记录，货币战争缺少对应的对局统计。货币战争需要记录完整对局次数、该局新解锁的投资策略和用时，便于玩家核对长期刷取结果。

## 变更内容

- 在执行“选择难度后开始对局”后启动本局计时并清空未完成旧局的临时状态
- 仅在最终选中带未解锁图鉴图标的投资策略且确认完成后，登记本局新解锁策略
- 同局策略名称去重；没有新策略时写入“无”
- 在执行“重开最终”后，将对局次数、策略列表和用时追加到 `config/backup/currency_count.txt`
- 从现有记录的最大对局次数续号，兼容中英文冒号格式和无法识别的旧行
- 写入失败时记录明确错误，缺少开始事件时不生成伪记录
- 增加记录持久化、计时重置、策略筛选和动作名称契约测试

## 测试情况

- [x] 28 项货币战争相关单元测试通过
- [x] 新增模块与测试完整 Ruff 检查
- [x] 仓库 CI crash-level Ruff 规则通过
- [x] Python 语法编译检查通过
- [x] 游戏内完整运行 1 局（9 分 36 秒）：正确记录第 1 局、3 个新解锁投资策略及用时

说明：全仓测试在当前本地环境中仍有与本 PR 无关的失败，包括未安装 `PyQt5`/`cv2`，以及一个既有倒计时文本编码用例失败。

## 关联 Issue

无。