### PR TITLE
fix(iron_blood): 修复特殊地图终点型3「觐见装置」F 提示不出现/绕路问题

### DIFF
--- a/simul.py
+++ b/simul.py
@@ -464,7 +464,7 @@ class SimulatedUniverse(UniverseUtils):
     def do_interaction(self):
         # is_killed：是否是禁用的交互（沉浸奖励、复活装置、下载装置）
         is_killed = False
-        if self._check_f_prompt(fresh=True):
+        if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
             for _ in range(4):
                 img = self.get_small_interaction_img(x=0.3181, y=0.4324, mask="mask_f")
                 text = self.ts.similar_list(self.tk.interacts, img)

--- a/simul.py
+++ b/simul.py
@@ -464,7 +464,7 @@ class SimulatedUniverse(UniverseUtils):
     def do_interaction(self):
         # is_killed：是否是禁用的交互（沉浸奖励、复活装置、下载装置）
         is_killed = False
-        if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True):
+        if self._check_f_prompt(fresh=True):
             for _ in range(4):
                 img = self.get_small_interaction_img(x=0.3181, y=0.4324, mask="mask_f")
                 text = self.ts.similar_list(self.tk.interacts, img)

--- a/test/test_issue57_endpoint_nudge.py
+++ b/test/test_issue57_endpoint_nudge.py
@@ -1,0 +1,262 @@
+"""Regression tests for the recorded endpoint interaction fix (issue #57)."""
+
+import importlib
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import cv2 as cv
+import numpy as np
+
+from tool.utils.image_tool import load_all_images_from_directory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+load_all_images_from_directory(str(ROOT / "resource" / "imgs"))
+
+simul_utils = importlib.import_module("tool.simul.utils")
+IronBloodUniverse = importlib.import_module("iron_blood").IronBloodUniverse
+
+
+class FPromptDetectionTest(unittest.TestCase):
+    def test_full_screen_match_updates_reverse_coordinates(self):
+        universe = simul_utils.UniverseUtils.__new__(simul_utils.UniverseUtils)
+        universe.screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        universe.xx = 1920
+        universe.yy = 1080
+        universe.scx = 1.0
+        universe.threshold = 0.96
+        universe.last_info = None
+
+        template = cv.imread(str(ROOT / "resource" / "imgs" / "f.jpg"))
+        x, y = 1086, 601
+        universe.screen[y:y + template.shape[0], x:x + template.shape[1]] = template
+
+        with patch.object(simul_utils.config, "mapping", ["f"]):
+            self.assertTrue(
+                universe.check(
+                    "f",
+                    0.4443,
+                    0.4417,
+                    mask="mask_f1",
+                    threshold=0.96,
+                    search_all=True,
+                )
+            )
+
+        expected_x = (1920 - (x + template.shape[1] / 2)) / 1920
+        expected_y = (1080 - (y + template.shape[0] / 2)) / 1080
+        self.assertAlmostEqual(expected_x, universe.tx, places=6)
+        self.assertAlmostEqual(expected_y, universe.ty, places=6)
+
+
+class EndpointControllerTest(unittest.TestCase):
+    @staticmethod
+    def make_universe(results):
+        universe = IronBloodUniverse.__new__(IronBloodUniverse)
+        universe.ang = 40.0
+        universe._endpoint_heading = 40.0
+        universe._endpoint_heading_target = None
+        universe.is_run = Mock(return_value=True)
+        universe._check_f_prompt = Mock(side_effect=results)
+        universe._match_device_label = Mock(return_value=None)
+        universe.get_screen = Mock()
+        universe.get_loc = Mock(return_value=True)
+        universe.now_loc = (0.0, 0.0)
+        universe.target_loc = (1.0, 1.0)
+        universe.target_type = 3
+        universe._stop = False
+        universe.xx = 1920
+        universe.yy = 1080
+        universe.update_direction_data = Mock()
+        return universe
+
+    @staticmethod
+    def manager():
+        manager = Mock()
+        manager.sleep = Mock()
+        manager.wait = Mock()
+        return manager
+
+    def test_nudge_checks_before_and_after_each_bounded_step(self):
+        universe = self.make_universe([False, False, True])
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertTrue(universe._nudge_forward_for_f(steps=3, step_seconds=0.2))
+
+        self.assertEqual(2, manager.press.call_count)
+        self.assertEqual(
+            [("w", 0.2), ("w", 0.2)],
+            [call.args for call in manager.press.call_args_list],
+        )
+        self.assertGreaterEqual(manager.keyUp.call_count, 2)
+        self.assertTrue(all(call.kwargs.get("force") for call in manager.keyUp.call_args_list))
+
+    def test_nudge_is_finite_when_prompt_never_appears(self):
+        universe = self.make_universe([False] * 8)
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertFalse(universe._nudge_forward_for_f(steps=3))
+
+        self.assertEqual(3, manager.press.call_count)
+        self.assertGreaterEqual(manager.keyUp.call_count, 2)
+
+    def test_type3_found_while_panning(self):
+        # entry check (miss), pan step 1 (miss), pan step 2 (hit)
+        universe = self.make_universe([False, False, True])
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertTrue(
+                universe._approach_type3_endpoint(
+                    max_rings=2, pan_steps=4, leg_seconds=0.3
+                )
+            )
+
+        # issue #57: the endpoint search must not reuse the noise-driven
+        # mode-1 steering at all.
+        universe.update_direction_data.assert_not_called()
+        manager.press.assert_not_called()
+        self.assertGreaterEqual(manager.keyUp.call_count, 1)
+        self.assertTrue(all(
+            call.kwargs.get("force") for call in manager.keyUp.call_args_list
+        ))
+
+    def test_type3_search_is_finite_when_prompt_never_appears(self):
+        # entry + ring0 pan(4) + ring0 leg(1) + ring1 pan(4) = 10 checks
+        universe = self.make_universe([False] * 10)
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertFalse(
+                universe._approach_type3_endpoint(
+                    max_rings=2, pan_steps=4, leg_seconds=0.3
+                )
+            )
+
+        universe.update_direction_data.assert_not_called()
+        manager.press.assert_not_called()
+        self.assertEqual(1, manager.keyDown.call_count)
+        self.assertGreaterEqual(manager.keyUp.call_count, 2)
+
+    def test_type3_found_immediately_does_not_move_or_pan(self):
+        universe = self.make_universe([True])
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertTrue(universe._approach_type3_endpoint())
+
+        universe.update_direction_data.assert_not_called()
+        manager.keyDown.assert_not_called()
+        manager.mouse_move.assert_not_called()
+        manager.press.assert_not_called()
+        manager.keyUp.assert_called()
+
+    def test_type3_does_not_reuse_heading_from_another_target(self):
+        # A heading captured for a different endpoint must not steer this one.
+        universe = self.make_universe([False, False, True])
+        universe.ang = 73.0
+        universe._endpoint_heading = 211.0
+        universe._endpoint_heading_target = (1.0, 1.0)
+        universe._endpoint_heading_time = 0.0
+        universe.target_loc = (2.0, 2.0)
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertTrue(
+                universe._approach_type3_endpoint(
+                    max_rings=2, pan_steps=4, leg_seconds=0.3
+                )
+            )
+
+        first_move = manager.mouse_move.call_args_list[0].args[0]
+        self.assertAlmostEqual(90.0, first_move, places=6)
+        universe.update_direction_data.assert_not_called()
+
+    def test_type3_visual_homing_walks_to_seen_device(self):
+        # entry check (miss), pan step 1 check (miss), then the label match
+        # appears, homing walks once and the second F check inside the walk
+        # hits.
+        universe = self.make_universe([False, False, False, True])
+        universe._match_device_label = Mock(return_value=(1100.0, 500.0, 0.8))
+        manager = self.manager()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            self.assertTrue(
+                universe._approach_type3_endpoint(
+                    max_rings=2, pan_steps=4, leg_seconds=0.3
+                )
+            )
+
+        universe.update_direction_data.assert_not_called()
+        manager.keyDown.assert_any_call("w", force=True)
+        self.assertTrue(all(
+            call.kwargs.get("force") for call in manager.keyUp.call_args_list
+        ))
+
+
+class NavigationContractTest(unittest.TestCase):
+    @staticmethod
+    def make_universe(target_type):
+        universe = IronBloodUniverse.__new__(IronBloodUniverse)
+        universe.target = {((93.0, 93.0), target_type)}
+        universe.target_loc = (93.0, 93.0)
+        universe.now_loc = (93.0, 93.0)
+        universe.target_type = target_type
+        universe._stop = False
+        universe.is_sprinting = 0
+        universe.quan = False
+        universe.bai_e = False
+        universe.skill_num = 9
+        universe.red_threshold = 4500
+        universe.trust_annotated_attack_targets = True
+        universe.get_screen = Mock()
+        universe.get_recent_target = Mock(return_value=((93.0, 93.0), target_type))
+        universe.update_direction_data = Mock(return_value=5.0)
+        universe.get_loc = Mock(return_value=True)
+        universe.is_run = Mock(return_value=True)
+        universe.set_path_state = Mock()
+        universe.ts = Mock()
+        universe.ts.similar.return_value = False
+        universe.good_f = Mock(return_value=(True, 0.1))
+        universe.nof = Mock(return_value=True)
+        return universe
+
+    def test_type3_calls_bounded_controller_and_then_interacts(self):
+        universe = self.make_universe(3)
+        universe._approach_type3_endpoint = Mock(return_value=True)
+        universe._check_f_prompt = Mock(return_value=False)
+        manager = Mock()
+        with (
+            patch("tool.simul.utils.key_mouse_manager", manager),
+            patch("tool.simul.utils.sprint"),
+            patch("tool.simul.utils.match_skill_numbers_in_region", return_value=None),
+        ):
+            universe.get_path_with_big_map()
+
+        universe._approach_type3_endpoint.assert_called_once_with()
+        universe.nof.assert_called_once_with(must_be="tp")
+        manager.press.assert_any_call("f", force=True)
+        mode_calls = [
+            call for call in universe.update_direction_data.call_args_list
+            if call.kwargs.get("mode") == 1
+        ]
+        self.assertEqual([], mode_calls)
+
+    def test_type2_uses_nudge_result_without_pressing_f_in_navigation(self):
+        universe = self.make_universe(2)
+        universe._check_f_prompt = Mock(return_value=False)
+        universe._nudge_forward_for_f = Mock(return_value=True)
+        manager = Mock()
+        with (
+            patch("tool.simul.utils.key_mouse_manager", manager),
+            patch("tool.simul.utils.sprint"),
+            patch("tool.simul.utils.match_skill_numbers_in_region", return_value=None),
+        ):
+            universe.get_path_with_big_map()
+
+        universe._nudge_forward_for_f.assert_called_once_with()
+        self.assertEqual(set(), universe.target)
+        self.assertFalse(any(
+            call.args and call.args[0] == "f"
+            for call in manager.press.call_args_list
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_issue57_endpoint_nudge.py
+++ b/test/test_issue57_endpoint_nudge.py
@@ -50,6 +50,35 @@ class FPromptDetectionTest(unittest.TestCase):
         self.assertAlmostEqual(expected_y, universe.ty, places=6)
 
 
+class DeviceLabelRegionTest(unittest.TestCase):
+    """The device label must only be trusted when it sits in the upper half of
+    the screen (the character is facing the device); a lower-half label means
+    the character has its back to the device (review feedback)."""
+
+    def _make(self):
+        universe = simul_utils.UniverseUtils.__new__(simul_utils.UniverseUtils)
+        universe.screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        universe.scx = 1.0
+        return universe
+
+    def test_label_in_upper_half_is_matched(self):
+        universe = self._make()
+        template = cv.imread(str(ROOT / "resource" / "imgs" / "gray_image" / "device.png"))
+        x, y = 900, 200  # upper half: facing the device
+        universe.screen[y:y + template.shape[0], x:x + template.shape[1]] = template
+        hit = universe._match_device_label()
+        self.assertIsNotNone(hit)
+        self.assertAlmostEqual(x + template.shape[1] / 2.0, hit[0], delta=2)
+        self.assertAlmostEqual(y + template.shape[0] / 2.0, hit[1], delta=2)
+
+    def test_label_in_lower_half_is_rejected(self):
+        universe = self._make()
+        template = cv.imread(str(ROOT / "resource" / "imgs" / "gray_image" / "device.png"))
+        x, y = 900, 800  # lower half: backed away, must not homing
+        universe.screen[y:y + template.shape[0], x:x + template.shape[1]] = template
+        self.assertIsNone(universe._match_device_label())
+
+
 class EndpointControllerTest(unittest.TestCase):
     @staticmethod
     def make_universe(results):

--- a/test/test_issue57_endpoint_nudge.py
+++ b/test/test_issue57_endpoint_nudge.py
@@ -59,24 +59,33 @@ class DeviceLabelRegionTest(unittest.TestCase):
         universe = simul_utils.UniverseUtils.__new__(simul_utils.UniverseUtils)
         universe.screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
         universe.scx = 1.0
+        universe.xx = 1920
+        universe.yy = 1080
+        universe._stop = False
+        universe.is_run = Mock(return_value=True)
+        universe.get_screen = Mock()
+        universe.check = Mock(return_value=False)
         return universe
 
-    def test_label_in_upper_half_is_matched(self):
+    def test_label_in_upper_half_steers_toward_device(self):
         universe = self._make()
         template = cv.imread(str(ROOT / "resource" / "imgs" / "gray_image" / "device.png"))
         x, y = 900, 200  # upper half: facing the device
         universe.screen[y:y + template.shape[0], x:x + template.shape[1]] = template
-        hit = universe._match_device_label()
-        self.assertIsNotNone(hit)
-        self.assertAlmostEqual(x + template.shape[1] / 2.0, hit[0], delta=2)
-        self.assertAlmostEqual(y + template.shape[0] / 2.0, hit[1], delta=2)
+        manager = Mock()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            universe._home_to_device(max_legs=1)
+        self.assertTrue(manager.mouse_move.called)
 
     def test_label_in_lower_half_is_rejected(self):
         universe = self._make()
         template = cv.imread(str(ROOT / "resource" / "imgs" / "gray_image" / "device.png"))
         x, y = 900, 800  # lower half: backed away, must not homing
         universe.screen[y:y + template.shape[0], x:x + template.shape[1]] = template
-        self.assertIsNone(universe._match_device_label())
+        manager = Mock()
+        with patch("tool.simul.utils.key_mouse_manager", manager):
+            universe._home_to_device(max_legs=1)
+        self.assertFalse(manager.mouse_move.called)
 
 
 class EndpointControllerTest(unittest.TestCase):
@@ -88,8 +97,10 @@ class EndpointControllerTest(unittest.TestCase):
         universe._endpoint_heading_target = None
         universe.is_run = Mock(return_value=True)
         universe.check = Mock(side_effect=lambda *a, **k: results.pop(0) if results else False)
-        universe._match_device_label = Mock(return_value=None)
+        universe._match_template_in_box = Mock(return_value=None)
         universe.get_screen = Mock()
+        universe.screen = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        universe.scx = 1.0
         universe.get_loc = Mock(return_value=True)
         universe.now_loc = (0.0, 0.0)
         universe.target_loc = (1.0, 1.0)
@@ -184,7 +195,6 @@ class EndpointControllerTest(unittest.TestCase):
         universe.ang = 73.0
         universe._endpoint_heading = 211.0
         universe._endpoint_heading_target = (1.0, 1.0)
-        universe._endpoint_heading_time = 0.0
         universe.target_loc = (2.0, 2.0)
         manager = self.manager()
         with patch("tool.simul.utils.key_mouse_manager", manager):
@@ -203,7 +213,7 @@ class EndpointControllerTest(unittest.TestCase):
         # appears, homing walks once and the second F check inside the walk
         # hits.
         universe = self.make_universe([False, False, False, True])
-        universe._match_device_label = Mock(return_value=(1100.0, 500.0, 0.8))
+        universe._match_template_in_box = Mock(return_value=(1100.0, 500.0, 0.8))
         manager = self.manager()
         with patch("tool.simul.utils.key_mouse_manager", manager):
             self.assertTrue(

--- a/test/test_issue57_endpoint_nudge.py
+++ b/test/test_issue57_endpoint_nudge.py
@@ -58,7 +58,7 @@ class EndpointControllerTest(unittest.TestCase):
         universe._endpoint_heading = 40.0
         universe._endpoint_heading_target = None
         universe.is_run = Mock(return_value=True)
-        universe._check_f_prompt = Mock(side_effect=results)
+        universe.check = Mock(side_effect=lambda *a, **k: results.pop(0) if results else False)
         universe._match_device_label = Mock(return_value=None)
         universe.get_screen = Mock()
         universe.get_loc = Mock(return_value=True)
@@ -220,7 +220,7 @@ class NavigationContractTest(unittest.TestCase):
     def test_type3_calls_bounded_controller_and_then_interacts(self):
         universe = self.make_universe(3)
         universe._approach_type3_endpoint = Mock(return_value=True)
-        universe._check_f_prompt = Mock(return_value=False)
+        universe.check = Mock(return_value=False)
         manager = Mock()
         with (
             patch("tool.simul.utils.key_mouse_manager", manager),
@@ -240,7 +240,7 @@ class NavigationContractTest(unittest.TestCase):
 
     def test_type2_uses_nudge_result_without_pressing_f_in_navigation(self):
         universe = self.make_universe(2)
-        universe._check_f_prompt = Mock(return_value=False)
+        universe.check = Mock(return_value=False)
         universe._nudge_forward_for_f = Mock(return_value=True)
         manager = Mock()
         with (

--- a/tool/log.py
+++ b/tool/log.py
@@ -228,7 +228,14 @@ class CusLogger(logging.Logger):
 
             def emit(self, record):
                 msg = self.format(record)
-                self.original_stdout.write(msg + '\n')
+                try:
+                    self.original_stdout.write(msg + '\n')
+                except UnicodeEncodeError:
+                    # 控制台使用 GBK 等窄编码时，日志中的特殊字符（如 ®）会触发
+                    # UnicodeEncodeError；若不加保护会顺着任务线程把整个运行带崩。
+                    enc = getattr(self.original_stdout, 'encoding', None) or 'gbk'
+                    line = (msg + '\n').encode(enc, errors='replace').decode(enc, errors='replace')
+                    self.original_stdout.write(line)
                 self.original_stdout.flush()
 
         console_handler = ConsoleOnlyHandler(original_stdout)

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -142,7 +142,6 @@ class UniverseUtils:
         # Last reliable bearing used for the final approach to a type-3 target.
         self._endpoint_heading = None
         self._endpoint_heading_target = None
-        self._endpoint_heading_time = 0.0
         #地图集合
         self.img_set = []
         #是否拥有黄泉
@@ -1114,7 +1113,6 @@ class UniverseUtils:
         self.now_loc = (93,93)
         self._endpoint_heading = None
         self._endpoint_heading_target = None
-        self._endpoint_heading_time = 0.0
         self.first_mini = 1
         self.find=1
         self.red_threshold = 4500
@@ -1245,7 +1243,6 @@ class UniverseUtils:
         if mode == 1 and getattr(self, "target_type", None) == 3 and ds >= 12:
             self._endpoint_heading = self.ang
             self._endpoint_heading_target = tuple(target_loc)
-            self._endpoint_heading_time = time.time()
         return ds
 
     def _walk_legs_for_f(self, legs, step_seconds=0.3, hold=True):
@@ -1258,7 +1255,8 @@ class UniverseUtils:
                 if getattr(self, "_stop", False) or not self.is_run():
                     return False
                 if hold:
-                    self._settle_input(step_seconds)
+                    key_mouse_manager.sleep(step_seconds)
+                    key_mouse_manager.wait()  # 保序：截图需在移动完成后
                 else:
                     key_mouse_manager.press("w", step_seconds)
                     key_mouse_manager.wait()  # 保序：截图需在移动完成后
@@ -1284,57 +1282,36 @@ class UniverseUtils:
         finally:
             self._release_forward()
 
-    def _settle_input(self, duration):
-        """移动一节的统一入口：sleep 走队列、可被强制操作打断，wait 保证截图时移动已完成。"""
-        key_mouse_manager.sleep(max(0.0, duration))
-        key_mouse_manager.wait()
-
     def _release_forward(self):
         """Cancel queued movement and release W immediately."""
         key_mouse_manager.keyUp("w", force=True)
         key_mouse_manager.wait()
         key_mouse_manager.clean()
 
-    def _match_device_label(self, threshold=0.62):
-        """在屏幕上定位觐见装置标签，返回 (center_x, center_y, score)，找不到返回 None。"""
-        try:
-            template = find_image_in_folder("gray_image/", "device.png")
-        except Exception:
-            return None
-        if template is None:
-            return None
-        if len(self.screen.shape) == 3:
-            gray = cv.cvtColor(self.screen, cv.COLOR_BGR2GRAY)
-        else:
-            gray = self.screen
-        try:
-            base_scale = float(getattr(self, "scx", 1.0)) or 1.0
-        except (TypeError, ValueError):
-            base_scale = 1.0
-        # 仅在上半区搜索标签（正面朝向才可见）；上半区匹配逻辑与
-        # check(search_all=True) 共用 _match_template_in_box。
-        best = self._match_template_in_box(
-            gray, template, self.DEVICE_LABEL_BOX,
-            scales=tuple(s * base_scale for s in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5)),
-            method=cv.TM_CCOEFF_NORMED,
-        )
-        if best is not None and best[2] >= threshold:
-            return best
-        return None
-
     def _home_to_device(self, max_legs=6):
-        """Steer toward the visible device label and walk until F appears."""
+        """朝可见的觐见装置标签转向并前进，直到 F 出现；找不到返回 False。"""
+        template = find_image_in_folder("gray_image/", "device.png")
+        if template is None:
+            return False
         for _ in range(max_legs):
             if getattr(self, "_stop", False) or not self.is_run():
                 return False
             self.get_screen()
-            hit = self._match_device_label()
-            if hit is None:
+            gray = cv.cvtColor(self.screen, cv.COLOR_BGR2GRAY)
+            hit = self._match_template_in_box(
+                gray, template, self.DEVICE_LABEL_BOX,
+                scales=tuple(s * self.scx for s in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5)),
+                method=cv.TM_CCOEFF_NORMED,
+            )
+            if hit is None or hit[2] < 0.62:
                 return False
-            cx, cy, score = hit
+            CUS_LOGGER.debug(
+                f"type3 device label at ({hit[0]:.0f},"
+                f"{hit[1]:.0f}) sim={hit[2]:.3f}; homing"
+            )
             half_w = float(getattr(self, "xx", 1920)) / 2.0
             # Same pixel-per-degree convention as move_direct_to_text.
-            dx_angle = (cx - half_w) / self.PIXEL_PER_DEG
+            dx_angle = (hit[0] - half_w) / self.PIXEL_PER_DEG
             if abs(dx_angle) >= 0.5:
                 self._turn_by(dx_angle)
             if self._walk_legs_for_f(3, 0.3, hold=True):
@@ -1385,17 +1362,8 @@ class UniverseUtils:
                     self._turn_by(pan_angle)
                     if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                         return True
-                    try:
-                        device_hit = self._match_device_label()
-                    except Exception:
-                        device_hit = None
-                    if device_hit is not None:
-                        CUS_LOGGER.debug(
-                            f"type3 device label at ({device_hit[0]:.0f},"
-                            f"{device_hit[1]:.0f}) sim={device_hit[2]:.3f}; homing"
-                        )
-                        if self._home_to_device():
-                            return True
+                    if self._home_to_device():
+                        return True
                 self.ang = (self.ang + pan_angle * pan_steps) % 360
                 # Leg: keep W held and walk forward on the current heading.
                 if ring < max_rings - 1:

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -471,6 +471,38 @@ class UniverseUtils:
     # 下半部分说明角色背对装置（此时朝标签方向走是反向的）。因此仅在屏幕
     # 上半区匹配标签，同时也避免全屏匹配的开销。
     DEVICE_LABEL_BOX = (0.05, 0.95, 0.02, 0.52)
+    # 视角旋转与鼠标像素的换算系数（px/度），与 key_mouse_manager 一致。
+    PIXEL_PER_DEG = 16.5
+
+    def _match_template_in_box(self, image, template, box, scales=(1.0,),
+                               method=cv.TM_CCORR_NORMED):
+        """Return (center_x, center_y, score) of the best template match inside
+        the normalized box (x0,x1,y0,y1), in full-image pixel coordinates, or
+        None when no scale fits.  Shared by check(search_all=True) and
+        _match_device_label so the region multi-scale search exists once.
+        """
+        fx0, fx1, fy0, fy1 = box
+        h, w = image.shape[:2]
+        ox, oy = int(w * fx0), int(h * fy0)
+        region = image[oy : int(h * fy1), ox : int(w * fx1)]
+        best = None
+        for scale in scales:
+            t = cv.resize(
+                template, None,
+                fx=scale, fy=scale,
+                interpolation=cv.INTER_CUBIC,
+            )
+            if t.shape[0] >= region.shape[0] or t.shape[1] >= region.shape[1]:
+                continue
+            result = cv.matchTemplate(region, t, method)
+            _, max_val, _, max_loc = cv.minMaxLoc(result)
+            if best is None or max_val > best[2]:
+                best = (
+                    ox + max_loc[0] + t.shape[1] / 2.0,
+                    oy + max_loc[1] + t.shape[0] / 2.0,
+                    float(max_val),
+                )
+        return best
 
     def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False, search_all=False):
         """
@@ -503,15 +535,18 @@ class UniverseUtils:
             # 与 (0.57,0.57)），固定点裁剪会漏检。全屏模板匹配可覆盖所有
             # 位置，但开销大（实测约 55ms/帧），故仅在 F_PROMPT_BOX 范围内
             # 搜索（覆盖已知位置并留有余量）。
-            fx0, fx1, fy0, fy1 = self.F_PROMPT_BOX
-            h_region = int(self.screen.shape[0] * fy1) - int(self.screen.shape[0] * fy0)
-            w_region = int(self.screen.shape[1] * fx1) - int(self.screen.shape[1] * fx0)
-            self._search_ox = int(self.screen.shape[1] * fx0)
-            self._search_oy = int(self.screen.shape[0] * fy0)
-            local_screen = self.screen[
-                self._search_oy : self._search_oy + h_region,
-                self._search_ox : self._search_ox + w_region,
-            ]
+            match = self._match_template_in_box(
+                self.screen, target, self.F_PROMPT_BOX,
+                method=cv.TM_CCORR_NORMED,
+            )
+            if match is None:
+                self.tm = -1.0
+                return False
+            # Coordinates used by this module are measured from the lower-right
+            # corner; _match_template_in_box already returns full-screen pixels.
+            max_val = match[2]
+            self.tx = (self.xx - match[0]) / self.xx
+            self.ty = (self.yy - match[1]) / self.yy
         else:
             if mask is None:
                 shape = target.shape
@@ -522,42 +557,31 @@ class UniverseUtils:
                     int(self.scx * mask_img.shape[1]),
                 )
             local_screen = self.get_local(x, y, shape)
-        if use_binary:
-            # 将截图和模板图像转换为灰度图
-            if len(local_screen.shape) == 3:
-                gray_screen = cv.cvtColor(local_screen, cv.COLOR_BGR2GRAY)
+            if use_binary:
+                # 将截图和模板图像转换为灰度图
+                if len(local_screen.shape) == 3:
+                    gray_screen = cv.cvtColor(local_screen, cv.COLOR_BGR2GRAY)
+                else:
+                    gray_screen = local_screen
+
+                if len(target.shape) == 3:
+                    gray_target = cv.cvtColor(target, cv.COLOR_BGR2GRAY)
+                else:
+                    gray_target = target
+
+                # 对截图和模板进行二值化处理
+                _, binary_screen = cv.threshold(gray_screen, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
+                _, binary_target = cv.threshold(gray_target, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
+
+                # 使用二值化图像进行匹配
+                result = cv.matchTemplate(binary_screen, binary_target, cv.TM_CCORR_NORMED)
             else:
-                gray_screen = local_screen
-
-            if len(target.shape) == 3:
-                gray_target = cv.cvtColor(target, cv.COLOR_BGR2GRAY)
-            else:
-                gray_target = target
-
-            # 对截图和模板进行二值化处理
-            _, binary_screen = cv.threshold(gray_screen, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
-            _, binary_target = cv.threshold(gray_target, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
-
-            # 使用二值化图像进行匹配
-            result = cv.matchTemplate(binary_screen, binary_target, cv.TM_CCORR_NORMED)
-        else:
-            try:
-                result = cv.matchTemplate(local_screen, target, cv.TM_CCORR_NORMED)
-            except Exception:
-                CUS_LOGGER.error(f"{path}匹配失败，源图像{local_screen.shape}，目标图像{target.shape}")
-                raise
-        min_val, max_val, min_loc, max_loc = cv.minMaxLoc(result)
-        if search_all:
-            # Coordinates used by this module are measured from the lower-right
-            # corner.  Convert the region match back to that coordinate system
-            # instead of applying the fixed-crop offset formula.  The match was
-            # computed on the F_PROMPT_BOX crop, so add the crop offset before
-            # normalising against the full screen.
-            match_center_x = self._search_ox + max_loc[0] + 0.5 * target.shape[1]
-            match_center_y = self._search_oy + max_loc[1] + 0.5 * target.shape[0]
-            self.tx = (self.xx - match_center_x) / self.xx
-            self.ty = (self.yy - match_center_y) / self.yy
-        else:
+                try:
+                    result = cv.matchTemplate(local_screen, target, cv.TM_CCORR_NORMED)
+                except Exception:
+                    CUS_LOGGER.error(f"{path}匹配失败，源图像{local_screen.shape}，目标图像{target.shape}")
+                    raise
+            min_val, max_val, min_loc, max_loc = cv.minMaxLoc(result)
             self.tx = x - (max_loc[0] - 0.5 * local_screen.shape[1] + 0.5 * target.shape[1]) / self.xx
             self.ty = y - (max_loc[1] - 0.5 * local_screen.shape[0] + 0.5 * target.shape[0]) / self.yy
         self.tm = max_val
@@ -1312,31 +1336,13 @@ class UniverseUtils:
             base_scale = float(getattr(self, "scx", 1.0)) or 1.0
         except (TypeError, ValueError):
             base_scale = 1.0
-        # 仅在上半区搜索标签（正面朝向才可见），坐标加回裁剪偏移后返回。
-        fx0, fx1, fy0, fy1 = self.DEVICE_LABEL_BOX
-        ox = int(gray.shape[1] * fx0)
-        oy = int(gray.shape[0] * fy0)
-        region = gray[
-            oy : int(gray.shape[0] * fy1),
-            ox : int(gray.shape[1] * fx1),
-        ]
-        best = None
-        for scale in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5):
-            t = cv.resize(
-                template, None,
-                fx=scale * base_scale, fy=scale * base_scale,
-                interpolation=cv.INTER_CUBIC,
-            )
-            if t.shape[0] >= region.shape[0] or t.shape[1] >= region.shape[1]:
-                continue
-            result = cv.matchTemplate(region, t, cv.TM_CCOEFF_NORMED)
-            _, max_val, _, max_loc = cv.minMaxLoc(result)
-            if best is None or max_val > best[2]:
-                best = (
-                    ox + max_loc[0] + t.shape[1] / 2.0,
-                    oy + max_loc[1] + t.shape[0] / 2.0,
-                    float(max_val),
-                )
+        # 仅在上半区搜索标签（正面朝向才可见）；上半区匹配逻辑与
+        # check(search_all=True) 共用 _match_template_in_box。
+        best = self._match_template_in_box(
+            gray, template, self.DEVICE_LABEL_BOX,
+            scales=tuple(s * base_scale for s in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5)),
+            method=cv.TM_CCOEFF_NORMED,
+        )
         if best is not None and best[2] >= threshold:
             return best
         return None
@@ -1353,7 +1359,7 @@ class UniverseUtils:
             cx, cy, score = hit
             half_w = float(getattr(self, "xx", 1920)) / 2.0
             # Same pixel-per-degree convention as move_direct_to_text.
-            dx_angle = (cx - half_w) / 16.5
+            dx_angle = (cx - half_w) / self.PIXEL_PER_DEG
             if abs(dx_angle) >= 0.5:
                 key_mouse_manager.mouse_move(dx_angle)
                 key_mouse_manager.wait()
@@ -3004,7 +3010,7 @@ class UniverseUtils:
             pos = get_text_position(self.get_screen())
             if pos:
                 CUS_LOGGER.debug(f"距离中心点{960 - pos[0][0]}，进行旋转")
-                key_mouse_manager.mouse_move((pos[0][0] - 960) / 16.5)
+                key_mouse_manager.mouse_move((pos[0][0] - self.xx / 2) / self.PIXEL_PER_DEG)
                 find=True
                 key_mouse_manager.wait()
                 break

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -139,6 +139,10 @@ class UniverseUtils:
         self.debug_map = None
         #目标坐标
         self.target_loc = None
+        # Last reliable bearing used for the final approach to a type-3 target.
+        self._endpoint_heading = None
+        self._endpoint_heading_target = None
+        self._endpoint_heading_time = 0.0
         #地图集合
         self.img_set = []
         #是否拥有黄泉
@@ -458,13 +462,15 @@ class UniverseUtils:
             )
         local_screen = self.get_local(x, y, shape, False)
         return local_screen
-    def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False):
+    def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False, search_all=False):
         """
         判断截图中匹配中心点附近是否存在匹配模板
         path：匹配模板的路径，
-        x,y：匹配中心点，
+        x,y：匹配中心点（search_all=False 时使用），
         mask：如果存在，则以mask大小为基准裁剪截图，
-        threshold：匹配阈值
+        threshold：匹配阈值，
+        search_all：True 时跳过固定点裁剪，直接对全屏做模板匹配
+                    （用于 F 提示位置会随 UI/体型/场景变化的场景，如 issue #57）。
         """
         if fresh:
             self.get_screen()
@@ -482,15 +488,21 @@ class UniverseUtils:
             target,
             dsize=(int(self.scx * target.shape[1]), int(self.scx * target.shape[0])),
         )
-        if mask is None:
-            shape = target.shape
+        if search_all:
+            # issue #57：F 提示位置随场景变化（如青女/觐见装置在屏幕
+            # 右中 ~(0.62,0.59)，而固定点仅覆盖 (0.44,0.44)），固定点裁剪
+            # 会漏检。改为全屏模板匹配，任何位置都能命中。
+            local_screen = self.screen
         else:
-            mask_img = find_image_by_name(mask)
-            shape = (
-                int(self.scx * mask_img.shape[0]),
-                int(self.scx * mask_img.shape[1]),
-            )
-        local_screen = self.get_local(x, y, shape)
+            if mask is None:
+                shape = target.shape
+            else:
+                mask_img = find_image_by_name(mask)
+                shape = (
+                    int(self.scx * mask_img.shape[0]),
+                    int(self.scx * mask_img.shape[1]),
+                )
+            local_screen = self.get_local(x, y, shape)
         if use_binary:
             # 将截图和模板图像转换为灰度图
             if len(local_screen.shape) == 3:
@@ -516,14 +528,36 @@ class UniverseUtils:
                 CUS_LOGGER.error(f"{path}匹配失败，源图像{local_screen.shape}，目标图像{target.shape}")
                 raise
         min_val, max_val, min_loc, max_loc = cv.minMaxLoc(result)
-        self.tx = x - (max_loc[0] - 0.5 * local_screen.shape[1] + 0.5 * target.shape[1]) / self.xx
-        self.ty = y - (max_loc[1] - 0.5 * local_screen.shape[0] + 0.5 * target.shape[0]) / self.yy
+        if search_all:
+            # Coordinates used by this module are measured from the lower-right
+            # corner.  Convert the full-screen match back to that coordinate
+            # system instead of applying the fixed-crop offset formula.
+            screen_height, screen_width = local_screen.shape[:2]
+            match_center_x = max_loc[0] + 0.5 * target.shape[1]
+            match_center_y = max_loc[1] + 0.5 * target.shape[0]
+            self.tx = (screen_width - match_center_x) / screen_width
+            self.ty = (screen_height - match_center_y) / screen_height
+        else:
+            self.tx = x - (max_loc[0] - 0.5 * local_screen.shape[1] + 0.5 * target.shape[1]) / self.xx
+            self.ty = y - (max_loc[1] - 0.5 * local_screen.shape[0] + 0.5 * target.shape[0]) / self.yy
         self.tm = max_val
         if max_val > threshold:
             if self.last_info != path:
                 CUS_LOGGER.debug(f"匹配到图片记忆切片 {path} 相似度 {max_val} 阈值 {threshold}")
             self.last_info = path
         return max_val > threshold
+
+    def _check_f_prompt(self, fresh=False):
+        """Detect the interaction prompt independently of its HUD position."""
+        return self.check(
+            "f",
+            0.4443,
+            0.4417,
+            mask="mask_f1",
+            threshold=0.96,
+            fresh=fresh,
+            search_all=True,
+        )
 
     def get_end_point(self, mask=0,device=0):
         self.get_screen()
@@ -1048,6 +1082,9 @@ class UniverseUtils:
         self.big_map=None
         self.big_map_init = False
         self.now_loc = (93,93)
+        self._endpoint_heading = None
+        self._endpoint_heading_target = None
+        self._endpoint_heading_time = 0.0
         self.first_mini = 1
         self.find=1
         self.red_threshold = 4500
@@ -1063,7 +1100,7 @@ class UniverseUtils:
         if must_be is None and (self.ts.similar("区域") or self.ts.similar("觐见")):
             must_be='tp'
         while not ava and time.time()-tm<1.8:
-            if not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96,fresh=True):
+            if not self._check_f_prompt(fresh=True):
                 if not self.is_run():
                     CUS_LOGGER.info("仿佛连深不见底的最初混沌，也能够烧却。")
                     ava = True
@@ -1074,11 +1111,11 @@ class UniverseUtils:
                 if not self.is_run():
                     CUS_LOGGER.info("…我以为，那就是世间最极致的力量，再无其他。")
                     ava=True
-                elif (not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96,fresh=True)) and must_be == 'tp':
+                elif (not self._check_f_prompt(fresh=True)) and must_be == 'tp':
                     CUS_LOGGER.info("或许只要短短万年的时光——它便会被烧成哀毁骨立的焦炭盗火行者了吧。")
                     ava=True
             else:
-                if not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True):
+                if not self._check_f_prompt(fresh=True):
                     ava=True
 
         if ava:
@@ -1173,7 +1210,239 @@ class UniverseUtils:
         # 此处变换为了目标角度
         self.ang = ang
         ds=get_dis(rel_loc, target_loc)
+        # Once the target is still far enough away, the minimap bearing is
+        # useful.  Keep the last such bearing for the final approach: position
+        # matching becomes noisy at the endpoint and repeatedly correcting from
+        # those samples can turn the character away from the interaction.
+        if mode == 1 and getattr(self, "target_type", None) == 3 and ds >= 12:
+            self._endpoint_heading = self.ang
+            self._endpoint_heading_target = tuple(target_loc)
+            self._endpoint_heading_time = time.time()
         return ds
+
+    def _nudge_forward_for_f(self, steps=3, step_seconds=0.25):
+        """Move a bounded number of short steps and look for the F prompt."""
+        steps = max(0, int(steps))
+        step_seconds = max(0.05, min(float(step_seconds), 0.4))
+        try:
+            self._release_forward()
+            self._settle_input(0.25)
+            if not self.is_run():
+                return False
+            if self._check_f_prompt(fresh=True):
+                return True
+            for _ in range(steps):
+                key_mouse_manager.press("w", step_seconds)
+                key_mouse_manager.wait()
+                if not self.is_run():
+                    return False
+                self._settle_input(0.15)
+                if self._check_f_prompt(fresh=True):
+                    return True
+            return False
+        finally:
+            self._release_forward()
+
+    def _settle_input(self, duration):
+        """Wait for queued input and a fresh frame before the next sample."""
+        key_mouse_manager.sleep(max(0.0, duration))
+        key_mouse_manager.wait()
+
+    def _release_forward(self):
+        """Cancel queued movement and release W immediately."""
+        key_mouse_manager.keyUp("w", force=True)
+        key_mouse_manager.wait()
+        key_mouse_manager.clean()
+
+    def _match_device_label(self, threshold=0.62):
+        """Locate the Jian Jian zhuangzhi name label on screen.
+
+        The recorded endpoint is only a map coordinate; on some maps the
+        device sits well beyond it (behind a wall or off the recorded
+        stroll), so probing in place never gets within prompt range.  The
+        in-game 觐见装置 label is always rendered above the device, so while
+        it is in view we can steer the camera toward it and walk straight at
+        it.  Returns (center_x, center_y, score) in game-window pixels or
+        None when the label is not on screen.
+        """
+        try:
+            template = find_image_in_folder("gray_image/", "device.png")
+        except Exception:
+            return None
+        if template is None:
+            return None
+        if len(self.screen.shape) == 3:
+            gray = cv.cvtColor(self.screen, cv.COLOR_BGR2GRAY)
+        else:
+            gray = self.screen
+        try:
+            base_scale = float(getattr(self, "scx", 1.0)) or 1.0
+        except (TypeError, ValueError):
+            base_scale = 1.0
+        best = None
+        for scale in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5):
+            t = cv.resize(
+                template, None,
+                fx=scale * base_scale, fy=scale * base_scale,
+                interpolation=cv.INTER_CUBIC,
+            )
+            if t.shape[0] >= gray.shape[0] or t.shape[1] >= gray.shape[1]:
+                continue
+            result = cv.matchTemplate(gray, t, cv.TM_CCOEFF_NORMED)
+            _, max_val, _, max_loc = cv.minMaxLoc(result)
+            if best is None or max_val > best[2]:
+                best = (
+                    max_loc[0] + t.shape[1] / 2.0,
+                    max_loc[1] + t.shape[0] / 2.0,
+                    float(max_val),
+                )
+        if best is not None and best[2] >= threshold:
+            return best
+        return None
+
+    def _home_to_device(self, max_legs=6):
+        """Steer toward the visible device label and walk until F appears."""
+        for _ in range(max_legs):
+            if getattr(self, "_stop", False) or not self.is_run():
+                return False
+            self.get_screen()
+            hit = self._match_device_label()
+            if hit is None:
+                return False
+            cx, cy, score = hit
+            half_w = float(getattr(self, "xx", 1920)) / 2.0
+            # Same pixel-per-degree convention as move_direct_to_text.
+            dx_angle = (cx - half_w) / 16.5
+            if abs(dx_angle) >= 0.5:
+                key_mouse_manager.mouse_move(dx_angle)
+                key_mouse_manager.wait()
+                self._settle_input(0.25)
+            key_mouse_manager.keyDown("w", force=True)
+            key_mouse_manager.wait()
+            for _ in range(3):
+                if getattr(self, "_stop", False) or not self.is_run():
+                    key_mouse_manager.keyUp("w", force=True)
+                    return False
+                self._settle_input(0.3)
+                if self._check_f_prompt(fresh=True):
+                    key_mouse_manager.keyUp("w", force=True)
+                    return True
+            key_mouse_manager.keyUp("w", force=True)
+            key_mouse_manager.wait()
+        return False
+
+    def _approach_type3_endpoint(self, max_rings=4, pan_steps=8, leg_seconds=0.6):
+        """Deterministically find the endpoint interaction prompt (issue #57).
+
+        The recorded end position is exactly where the prompt was visible when
+        the map was recorded, so the interaction is always within a few metres
+        of the recorded coordinate.  get_loc() is +/-10 units noisy there and
+        the old mode=1 steering (derived from that noise) kept spinning the
+        character without ever facing the device.  This search is therefore
+        coordinate-free:
+
+        1. while panning, match the in-game 觐见装置 label on screen and, when
+           it is visible, steer the camera toward it and walk straight at it
+           (visual homing - handles devices that sit beyond the recorded
+           coordinate or behind small obstacles);
+        2. stand still and pan the camera a full circle, checking for the F
+           prompt on every step (the prompt is screen-space, so facing the
+           device is what matters);
+        3. walk a short leg in the last reliable bearing (captured while the
+           target was still >12 units away), then turn 90 degrees;
+        4. each ring pans another full circle while the legs form a square
+           spiral around the recorded point.
+
+        Everything is bounded: max_rings rings keep the runtime under roughly
+        a minute and the caller simply retries if the prompt never shows.
+        """
+        max_rings = max(1, min(int(max_rings), 6))
+        pan_steps = max(4, min(int(pan_steps), 12))
+        leg_seconds = max(0.3, min(float(leg_seconds), 1.5))
+        try:
+            self._release_forward()
+            self._settle_input(0.25)
+            if not self.is_run():
+                return False
+            if self._check_f_prompt(fresh=True):
+                return True
+
+            # Face the last reliable bearing so the first leg heads toward the
+            # device instead of a noise-derived direction.  Only reuse it when
+            # it was captured for this exact endpoint.
+            heading = getattr(self, "_endpoint_heading", None)
+            heading_target = getattr(self, "_endpoint_heading_target", None)
+            if heading is not None and heading_target is not None:
+                try:
+                    if tuple(heading_target) != tuple(self.target_loc):
+                        heading = None
+                except (TypeError, ValueError):
+                    heading = None
+            if heading is not None:
+                turn = (heading - self.ang + 180) % 360 - 180
+                key_mouse_manager.mouse_move(turn)
+                key_mouse_manager.wait()
+                self.ang = heading % 360
+                CUS_LOGGER.debug(
+                    f"type3 endpoint aligned to stored heading {heading:.1f}"
+                )
+            else:
+                key_mouse_manager.mouse_move(90)
+                key_mouse_manager.wait()
+                self.ang = (self.ang + 90) % 360
+
+            pan_angle = 360.0 / pan_steps
+            leg_ticks = max(1, int(round(leg_seconds / 0.3)))
+            for ring in range(max_rings):
+                if getattr(self, "_stop", False) or not self.is_run():
+                    return False
+                # Stand-still pan: a device right beside the character is found
+                # even when the character has been facing away from it.
+                key_mouse_manager.keyUp("w", force=True)
+                key_mouse_manager.wait()
+                for _ in range(pan_steps):
+                    if getattr(self, "_stop", False) or not self.is_run():
+                        return False
+                    key_mouse_manager.mouse_move(pan_angle)
+                    key_mouse_manager.wait()
+                    key_mouse_manager.sleep(0.3)
+                    key_mouse_manager.wait()
+                    if self._check_f_prompt(fresh=True):
+                        return True
+                    try:
+                        device_hit = self._match_device_label()
+                    except Exception:
+                        device_hit = None
+                    if device_hit is not None:
+                        CUS_LOGGER.debug(
+                            f"type3 device label at ({device_hit[0]:.0f},"
+                            f"{device_hit[1]:.0f}) sim={device_hit[2]:.3f}; homing"
+                        )
+                        if self._home_to_device():
+                            return True
+                self.ang = (self.ang + pan_angle * pan_steps) % 360
+                # Leg: keep W held and walk forward on the current heading.
+                if ring < max_rings - 1:
+                    key_mouse_manager.keyDown("w")
+                    key_mouse_manager.wait()
+                    for _ in range(leg_ticks):
+                        if getattr(self, "_stop", False) or not self.is_run():
+                            key_mouse_manager.keyUp("w", force=True)
+                            return False
+                        self._settle_input(0.3)
+                        if self._check_f_prompt(fresh=True):
+                            key_mouse_manager.keyUp("w", force=True)
+                            return True
+                    key_mouse_manager.keyUp("w", force=True)
+                    key_mouse_manager.wait()
+                    # Turn 90 degrees so consecutive legs form a square spiral.
+                    key_mouse_manager.mouse_move(90)
+                    key_mouse_manager.wait()
+                    self.ang = (self.ang + 90) % 360
+            return False
+        finally:
+            self._release_forward()
+
     # 寻路函数
     def get_direct_with_big_map(self):
         """
@@ -1359,13 +1628,15 @@ class UniverseUtils:
                 key_mouse_manager.wait()
             self.set_path_state("结束寻路")
             CUS_LOGGER.info(f"寻路判断已到达交互点附近 {now_distance}")
-            key_mouse_manager.clean()
-            key_mouse_manager.keyUp("w")
-            key_mouse_manager.wait()
+            self._release_forward()
             if not self.get_loc():
                 CUS_LOGGER.info("结束寻路后后不在大地图界面，返回")
                 return
-            if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96,fresh=True):
+            f_found = self._check_f_prompt(fresh=True)
+            if not f_found and self.target_type == 2:
+                # issue #57：交互点 F 提示需贴近才出现，先小碎步贴脸再检测
+                f_found = self._nudge_forward_for_f()
+            if f_found:
                 if self.target_type != 3 and self.good_f()[0] and not self.ts.similar("黑塔"):
                     self.set_path_state("位于交互点，移除交互点")
                     for j in deepcopy(self.target):
@@ -1411,24 +1682,14 @@ class UniverseUtils:
                     key_mouse_manager.click(0.5, 0.5)
             if self.target_type == 3:
                 self.set_path_state("当前寻找终点")
-                for i in range(9):
-                    self.get_screen()
-                    if not self.is_run():
-                        CUS_LOGGER.info("找终点时不在大地图，返回")
-                        return
-                    if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96):
-                        CUS_LOGGER.info("大图识别到类型三传送点")
-                        key_mouse_manager.press('f',force= True)
-                        key_mouse_manager.wait()
-                        if self.nof(must_be='tp'):
-                            return
-                    if not self.is_run():
-                        return
-                    if i in [0,4]:
-                        self.move_to_end(mode=1)
-                    key_mouse_manager.press('w')
+                if self._approach_type3_endpoint():
+                    CUS_LOGGER.info("type3 endpoint prompt detected")
+                    key_mouse_manager.press("f", force=True)
                     key_mouse_manager.wait()
-            # 离目标点挺近了，准备找下一个目标点
+                    if self.nof(must_be="tp"):
+                        return
+                else:
+                    CUS_LOGGER.debug("type3 endpoint prompt not found; retrying")
             elif now_distance <= 20:
                 self.set_path_state("距离目标非常近")
                 try:
@@ -2981,9 +3242,7 @@ class UniverseUtils:
             key_mouse_manager.wait()
         CUS_LOGGER.info("现在，一轮太阳将走向陨落，它顷刻便能将这荒诞的时空焚烧殆尽——")
         CUS_LOGGER.debug(f"寻路判断已到达交互点附近 {now_distance}")
-        key_mouse_manager.clean()
-        key_mouse_manager.keyUp("w")
-        key_mouse_manager.wait()
+        self._release_forward()
         if not self.get_loc():
             CUS_LOGGER.info("「救世主」…我愿你…常战常胜。")
             return
@@ -2993,7 +3252,11 @@ class UniverseUtils:
             self.last_interact_time = time.time()
             self.target.discard((self.target_loc, 1))
             return
-        if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True):
+        f_found = self._check_f_prompt(fresh=True)
+        if not f_found and self.target_type == 2:
+            # issue #57：交互点 F 提示需贴近才出现，先小碎步贴脸再检测
+            f_found = self._nudge_forward_for_f()
+        if f_found:
             if self.target_type != 3 and self.good_f()[0] and not self.ts.similar("黑塔"):
                 CUS_LOGGER.info(f"{factor}…别无选择。")
                 for j in deepcopy(self.target):
@@ -3047,25 +3310,15 @@ class UniverseUtils:
             else:
                 key_mouse_manager.click(0.5, 0.5)
         if self.target_type == 3:
-            CUS_LOGGER.info("何不…让愤怒…焚化命运…？卡…厄斯……")
-            for i in range(9):
-                self.get_screen()
-                if not self.is_run():
-                    CUS_LOGGER.info("沿着我们的足迹……写下前所未有的结局。")
-                    return
-                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96):
-                    CUS_LOGGER.info("那一定是个不同以往的浪漫故事。")
-                    key_mouse_manager.press('f', force=True)
-                    key_mouse_manager.wait()
-                    if self.nof(must_be='tp'):
-                        return
-                if not self.is_run():
-                    return
-                if i in [0, 4]:
-                    self.move_to_end(mode=1,device=1)
-                key_mouse_manager.press('w')
+            CUS_LOGGER.info("approaching type3 endpoint")
+            if self._approach_type3_endpoint():
+                CUS_LOGGER.info("type3 endpoint prompt detected")
+                key_mouse_manager.press("f", force=True)
                 key_mouse_manager.wait()
-        # 离目标点挺近了，准备找下一个目标点
+                if self.nof(must_be="tp"):
+                    return
+            else:
+                CUS_LOGGER.debug("type3 endpoint prompt not found; retrying")
         elif now_distance <= 20:
             CUS_LOGGER.info("你也是这么想的……对吧？")
             try:

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -463,9 +463,9 @@ class UniverseUtils:
         local_screen = self.get_local(x, y, shape, False)
         return local_screen
     # 交互提示（F）可能出现的屏幕范围（归一化 x0,x1,y0,y1）。
-    # 实测 F 会出现在 (0.44,0.44)（旧固定点）与 (0.57,0.57)/(0.62,0.59)（
-    # 青女/觐见装置场景），在全屏以外的固定位置匹配会漏检；对整屏做模板
-    # 匹配又有明显开销，因此限定在交互提示实际可能出现的区域内搜索。
+    # 实测 F 会出现在 (0.44,0.44)（旧固定点）与 (0.57,0.57)（实机截图模板
+    # 扫描 0.976 命中）两处；固定点匹配会漏检，而全屏匹配开销明显，因此
+    # 限定在覆盖已知位置并留有余量的区域内搜索。
     F_PROMPT_BOX = (0.20, 0.90, 0.25, 0.85)
 
     def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False, search_all=False):
@@ -495,10 +495,10 @@ class UniverseUtils:
             dsize=(int(self.scx * target.shape[1]), int(self.scx * target.shape[0])),
         )
         if search_all:
-            # issue #57：F 提示位置随场景变化（如青女/觐见装置在屏幕
-            # 右中 ~(0.62,0.59)，而固定点仅覆盖 (0.44,0.44)），固定点裁剪
-            # 会漏检。全屏模板匹配可覆盖所有位置，但开销大（实测约
-            # 100ms/帧），故仅在 F_PROMPT_BOX 范围内搜索。
+            # issue #57：F 提示位置随场景变化（实测两处：固定点 (0.44,0.44)
+            # 与 (0.57,0.57)），固定点裁剪会漏检。全屏模板匹配可覆盖所有
+            # 位置，但开销大（实测约 55ms/帧），故仅在 F_PROMPT_BOX 范围内
+            # 搜索（覆盖已知位置并留有余量）。
             fx0, fx1, fy0, fy1 = self.F_PROMPT_BOX
             h_region = int(self.screen.shape[0] * fy1) - int(self.screen.shape[0] * fy0)
             w_region = int(self.screen.shape[1] * fx1) - int(self.screen.shape[1] * fx0)

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -1233,7 +1233,6 @@ class UniverseUtils:
                 return True
             for _ in range(steps):
                 key_mouse_manager.press("w", step_seconds)
-                key_mouse_manager.wait()
                 if not self.is_run():
                     return False
                 self._settle_input(0.15)
@@ -1315,10 +1314,8 @@ class UniverseUtils:
             dx_angle = (cx - half_w) / 16.5
             if abs(dx_angle) >= 0.5:
                 key_mouse_manager.mouse_move(dx_angle)
-                key_mouse_manager.wait()
                 self._settle_input(0.25)
             key_mouse_manager.keyDown("w", force=True)
-            key_mouse_manager.wait()
             for _ in range(3):
                 if getattr(self, "_stop", False) or not self.is_run():
                     key_mouse_manager.keyUp("w", force=True)
@@ -1404,9 +1401,7 @@ class UniverseUtils:
                     if getattr(self, "_stop", False) or not self.is_run():
                         return False
                     key_mouse_manager.mouse_move(pan_angle)
-                    key_mouse_manager.wait()
-                    key_mouse_manager.sleep(0.3)
-                    key_mouse_manager.wait()
+                    self._settle_input(0.3)
                     if self._check_f_prompt(fresh=True):
                         return True
                     try:
@@ -1424,7 +1419,6 @@ class UniverseUtils:
                 # Leg: keep W held and walk forward on the current heading.
                 if ring < max_rings - 1:
                     key_mouse_manager.keyDown("w")
-                    key_mouse_manager.wait()
                     for _ in range(leg_ticks):
                         if getattr(self, "_stop", False) or not self.is_run():
                             key_mouse_manager.keyUp("w", force=True)

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -467,6 +467,10 @@ class UniverseUtils:
     # 扫描 0.976 命中）两处；固定点匹配会漏检，而全屏匹配开销明显，因此
     # 限定在覆盖已知位置并留有余量的区域内搜索。
     F_PROMPT_BOX = (0.20, 0.90, 0.25, 0.85)
+    # 「觐见装置」标签只在角色正面朝向装置时出现在屏幕上半部分；标签出现在
+    # 下半部分说明角色背对装置（此时朝标签方向走是反向的）。因此仅在屏幕
+    # 上半区匹配标签，同时也避免全屏匹配的开销。
+    DEVICE_LABEL_BOX = (0.05, 0.95, 0.02, 0.52)
 
     def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False, search_all=False):
         """
@@ -1285,6 +1289,14 @@ class UniverseUtils:
             base_scale = float(getattr(self, "scx", 1.0)) or 1.0
         except (TypeError, ValueError):
             base_scale = 1.0
+        # 仅在上半区搜索标签（正面朝向才可见），坐标加回裁剪偏移后返回。
+        fx0, fx1, fy0, fy1 = self.DEVICE_LABEL_BOX
+        ox = int(gray.shape[1] * fx0)
+        oy = int(gray.shape[0] * fy0)
+        region = gray[
+            oy : int(gray.shape[0] * fy1),
+            ox : int(gray.shape[1] * fx1),
+        ]
         best = None
         for scale in (0.7, 0.85, 1.0, 1.15, 1.3, 1.5):
             t = cv.resize(
@@ -1292,14 +1304,14 @@ class UniverseUtils:
                 fx=scale * base_scale, fy=scale * base_scale,
                 interpolation=cv.INTER_CUBIC,
             )
-            if t.shape[0] >= gray.shape[0] or t.shape[1] >= gray.shape[1]:
+            if t.shape[0] >= region.shape[0] or t.shape[1] >= region.shape[1]:
                 continue
-            result = cv.matchTemplate(gray, t, cv.TM_CCOEFF_NORMED)
+            result = cv.matchTemplate(region, t, cv.TM_CCOEFF_NORMED)
             _, max_val, _, max_loc = cv.minMaxLoc(result)
             if best is None or max_val > best[2]:
                 best = (
-                    max_loc[0] + t.shape[1] / 2.0,
-                    max_loc[1] + t.shape[0] / 2.0,
+                    ox + max_loc[0] + t.shape[1] / 2.0,
+                    oy + max_loc[1] + t.shape[0] / 2.0,
                     float(max_val),
                 )
         if best is not None and best[2] >= threshold:

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -630,6 +630,13 @@ class UniverseUtils:
             else:
                 return -((-dx) ** 0.7)
 
+    def _turn_by(self, delta, update_ang=False):
+        """转视角 delta 度并等队列排空，update_ang=True 时同步 self.ang。"""
+        key_mouse_manager.mouse_move(delta)
+        key_mouse_manager.wait()
+        if update_ang:
+            self.ang = (self.ang + delta) % 360
+
     def move_to_end(self, i=0,mode=0,device=0):
         CUS_LOGGER.debug(f"一人前往未来……一人留在过去。(类型{mode})")
         dx = self.get_end_point(i,device)
@@ -643,29 +650,24 @@ class UniverseUtils:
             if dx is None:
                 CUS_LOGGER.debug('…找到那个新生的「我」…让他延续三千万世的徒劳。')
                 for k in [60,120,60,60,30,30,-60,-60,-60,-60,-60,-60]:
-                    key_mouse_manager.mouse_move(-k)
-                    key_mouse_manager.wait()
+                    self._turn_by(-k)
                     off += k
                     dx = self.get_end_point(device=device)
                     if dx is not None:
                         break
                 if dx is None:
-                    key_mouse_manager.mouse_move(off*1.03)
-                    key_mouse_manager.wait()
+                    self._turn_by(off*1.03)
                     CUS_LOGGER.warning(f"即便理智随身形一起化作焦炭，{factor}也会记得自己的使命……(旋转未找到终点)")
                     return 0
         CUS_LOGGER.debug(f"移动面向终点 参数{i}移动距离{dx}")
         if i == 0:
-            key_mouse_manager.mouse_move(dx / 3)
-            key_mouse_manager.wait()
+            self._turn_by(dx / 3)
         else:
-            key_mouse_manager.mouse_move(dx / 5)
-            key_mouse_manager.wait()
+            self._turn_by(dx / 5)
         if i == 0 and abs(dx / 3) > 30:
             dx = self.get_end_point(1,device=device)
             if dx is not None:
-                key_mouse_manager.mouse_move(dx / 4)
-                key_mouse_manager.wait()
+                self._turn_by(dx / 4)
         return 1
 
 
@@ -1361,8 +1363,7 @@ class UniverseUtils:
             # Same pixel-per-degree convention as move_direct_to_text.
             dx_angle = (cx - half_w) / self.PIXEL_PER_DEG
             if abs(dx_angle) >= 0.5:
-                key_mouse_manager.mouse_move(dx_angle)
-                key_mouse_manager.wait()
+                self._turn_by(dx_angle)
             if self._walk_legs_for_f(3, 0.3, hold=True):
                 return True
         return False
@@ -1415,16 +1416,12 @@ class UniverseUtils:
                     heading = None
             if heading is not None:
                 turn = (heading - self.ang + 180) % 360 - 180
-                key_mouse_manager.mouse_move(turn)
-                key_mouse_manager.wait()
-                self.ang = heading % 360
+                self._turn_by(turn, update_ang=True)
                 CUS_LOGGER.debug(
                     f"type3 endpoint aligned to stored heading {heading:.1f}"
                 )
             else:
-                key_mouse_manager.mouse_move(90)
-                key_mouse_manager.wait()
-                self.ang = (self.ang + 90) % 360
+                self._turn_by(90, update_ang=True)
 
             pan_angle = 360.0 / pan_steps
             leg_ticks = max(1, int(round(leg_seconds / 0.3)))
@@ -1438,8 +1435,7 @@ class UniverseUtils:
                 for _ in range(pan_steps):
                     if getattr(self, "_stop", False) or not self.is_run():
                         return False
-                    key_mouse_manager.mouse_move(pan_angle)
-                    key_mouse_manager.wait()
+                    self._turn_by(pan_angle)
                     if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                         return True
                     try:
@@ -1459,9 +1455,7 @@ class UniverseUtils:
                     if self._walk_legs_for_f(leg_ticks, 0.3, hold=True):
                         return True
                     # Turn 90 degrees so consecutive legs form a square spiral.
-                    key_mouse_manager.mouse_move(90)
-                    key_mouse_manager.wait()
-                    self.ang = (self.ang + 90) % 360
+                    self._turn_by(90, update_ang=True)
             return False
         finally:
             self._release_forward()

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -476,11 +476,7 @@ class UniverseUtils:
 
     def _match_template_in_box(self, image, template, box, scales=(1.0,),
                                method=cv.TM_CCORR_NORMED):
-        """Return (center_x, center_y, score) of the best template match inside
-        the normalized box (x0,x1,y0,y1), in full-image pixel coordinates, or
-        None when no scale fits.  Shared by check(search_all=True) and
-        _match_device_label so the region multi-scale search exists once.
-        """
+        """在归一化区域 (x0,x1,y0,y1) 内多尺度匹配模板，返回 (center_x, center_y, score)，无匹配返回 None。"""
         fx0, fx1, fy0, fy1 = box
         h, w = image.shape[:2]
         ox, oy = int(w * fx0), int(h * fy0)
@@ -1244,10 +1240,8 @@ class UniverseUtils:
         # 此处变换为了目标角度
         self.ang = ang
         ds=get_dis(rel_loc, target_loc)
-        # Once the target is still far enough away, the minimap bearing is
-        # useful.  Keep the last such bearing for the final approach: position
-        # matching becomes noisy at the endpoint and repeatedly correcting from
-        # those samples can turn the character away from the interaction.
+        # 目标够远时小地图方位才可靠，存下最后一次供终点接近用；终点附近
+        # 定位噪声大，反复纠偏会把角色转离交互点。
         if mode == 1 and getattr(self, "target_type", None) == 3 and ds >= 12:
             self._endpoint_heading = self.ang
             self._endpoint_heading_target = tuple(target_loc)
@@ -1255,14 +1249,7 @@ class UniverseUtils:
         return ds
 
     def _walk_legs_for_f(self, legs, step_seconds=0.3, hold=True):
-        """Walk bounded legs and look for the F prompt after every leg.
-
-        hold=True keeps W pressed across all legs (one keyDown/keyUp pair);
-        hold=False taps W for step_seconds per leg.  W is released before
-        returning either way.  Shared by endpoint nudging (_nudge_forward_for_f),
-        device homing (_home_to_device) and the square-spiral legs of
-        _approach_type3_endpoint so all three reuse one walk-and-check loop.
-        """
+        """走 legs 段、每段后查一次 F。hold=True 全程按住 W，False 每段点按；退出前都会松开 W。"""
         if hold:
             key_mouse_manager.keyDown("w", force=True)
             key_mouse_manager.wait()
@@ -1298,12 +1285,7 @@ class UniverseUtils:
             self._release_forward()
 
     def _settle_input(self, duration):
-        """Run one bounded forward-movement leg.
-
-        The sleep is queue-ordered and interruptible (force ops such as
-        stop()/keyUp can cut it short); wait() then blocks until the queue
-        drains, so the following sample always sees the finished movement.
-        """
+        """移动一节的统一入口：sleep 走队列、可被强制操作打断，wait 保证截图时移动已完成。"""
         key_mouse_manager.sleep(max(0.0, duration))
         key_mouse_manager.wait()
 
@@ -1314,16 +1296,7 @@ class UniverseUtils:
         key_mouse_manager.clean()
 
     def _match_device_label(self, threshold=0.62):
-        """Locate the Jian Jian zhuangzhi name label on screen.
-
-        The recorded endpoint is only a map coordinate; on some maps the
-        device sits well beyond it (behind a wall or off the recorded
-        stroll), so probing in place never gets within prompt range.  The
-        in-game 觐见装置 label is always rendered above the device, so while
-        it is in view we can steer the camera toward it and walk straight at
-        it.  Returns (center_x, center_y, score) in game-window pixels or
-        None when the label is not on screen.
-        """
+        """在屏幕上定位觐见装置标签，返回 (center_x, center_y, score)，找不到返回 None。"""
         try:
             template = find_image_in_folder("gray_image/", "device.png")
         except Exception:
@@ -1369,30 +1342,7 @@ class UniverseUtils:
         return False
 
     def _approach_type3_endpoint(self, max_rings=4, pan_steps=8, leg_seconds=0.6):
-        """Deterministically find the endpoint interaction prompt (issue #57).
-
-        The recorded end position is exactly where the prompt was visible when
-        the map was recorded, so the interaction is always within a few metres
-        of the recorded coordinate.  get_loc() is +/-10 units noisy there and
-        the old mode=1 steering (derived from that noise) kept spinning the
-        character without ever facing the device.  This search is therefore
-        coordinate-free:
-
-        1. while panning, match the in-game 觐见装置 label on screen and, when
-           it is visible, steer the camera toward it and walk straight at it
-           (visual homing - handles devices that sit beyond the recorded
-           coordinate or behind small obstacles);
-        2. stand still and pan the camera a full circle, checking for the F
-           prompt on every step (the prompt is screen-space, so facing the
-           device is what matters);
-        3. walk a short leg in the last reliable bearing (captured while the
-           target was still >12 units away), then turn 90 degrees;
-        4. each ring pans another full circle while the legs form a square
-           spiral around the recorded point.
-
-        Everything is bounded: max_rings rings keep the runtime under roughly
-        a minute and the caller simply retries if the prompt never shows.
-        """
+        """issue #57 终点搜索：不依赖坐标——原地转圈查 F、看到装置标签就视觉寻的、按存下的可靠方位走正方形螺旋，全有界。"""
         max_rings = max(1, min(int(max_rings), 6))
         pan_steps = max(4, min(int(pan_steps), 12))
         leg_seconds = max(0.3, min(float(leg_seconds), 1.5))
@@ -1403,9 +1353,7 @@ class UniverseUtils:
             if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                 return True
 
-            # Face the last reliable bearing so the first leg heads toward the
-            # device instead of a noise-derived direction.  Only reuse it when
-            # it was captured for this exact endpoint.
+            # 先转向存下的可靠方位再走第一段腿；该方位必须属于当前终点。
             heading = getattr(self, "_endpoint_heading", None)
             heading_target = getattr(self, "_endpoint_heading_target", None)
             if heading is not None and heading_target is not None:
@@ -1428,8 +1376,7 @@ class UniverseUtils:
             for ring in range(max_rings):
                 if getattr(self, "_stop", False) or not self.is_run():
                     return False
-                # Stand-still pan: a device right beside the character is found
-                # even when the character has been facing away from it.
+                # 站桩转圈：贴脸装置即使背对也能找到。
                 key_mouse_manager.keyUp("w", force=True)
                 key_mouse_manager.wait()
                 for _ in range(pan_steps):

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -462,6 +462,12 @@ class UniverseUtils:
             )
         local_screen = self.get_local(x, y, shape, False)
         return local_screen
+    # 交互提示（F）可能出现的屏幕范围（归一化 x0,x1,y0,y1）。
+    # 实测 F 会出现在 (0.44,0.44)（旧固定点）与 (0.57,0.57)/(0.62,0.59)（
+    # 青女/觐见装置场景），在全屏以外的固定位置匹配会漏检；对整屏做模板
+    # 匹配又有明显开销，因此限定在交互提示实际可能出现的区域内搜索。
+    F_PROMPT_BOX = (0.20, 0.90, 0.25, 0.85)
+
     def check(self, path, x, y, mask=None, threshold=None, use_binary=False,fresh=False, search_all=False):
         """
         判断截图中匹配中心点附近是否存在匹配模板
@@ -491,8 +497,17 @@ class UniverseUtils:
         if search_all:
             # issue #57：F 提示位置随场景变化（如青女/觐见装置在屏幕
             # 右中 ~(0.62,0.59)，而固定点仅覆盖 (0.44,0.44)），固定点裁剪
-            # 会漏检。改为全屏模板匹配，任何位置都能命中。
-            local_screen = self.screen
+            # 会漏检。全屏模板匹配可覆盖所有位置，但开销大（实测约
+            # 100ms/帧），故仅在 F_PROMPT_BOX 范围内搜索。
+            fx0, fx1, fy0, fy1 = self.F_PROMPT_BOX
+            h_region = int(self.screen.shape[0] * fy1) - int(self.screen.shape[0] * fy0)
+            w_region = int(self.screen.shape[1] * fx1) - int(self.screen.shape[1] * fx0)
+            self._search_ox = int(self.screen.shape[1] * fx0)
+            self._search_oy = int(self.screen.shape[0] * fy0)
+            local_screen = self.screen[
+                self._search_oy : self._search_oy + h_region,
+                self._search_ox : self._search_ox + w_region,
+            ]
         else:
             if mask is None:
                 shape = target.shape
@@ -530,13 +545,14 @@ class UniverseUtils:
         min_val, max_val, min_loc, max_loc = cv.minMaxLoc(result)
         if search_all:
             # Coordinates used by this module are measured from the lower-right
-            # corner.  Convert the full-screen match back to that coordinate
-            # system instead of applying the fixed-crop offset formula.
-            screen_height, screen_width = local_screen.shape[:2]
-            match_center_x = max_loc[0] + 0.5 * target.shape[1]
-            match_center_y = max_loc[1] + 0.5 * target.shape[0]
-            self.tx = (screen_width - match_center_x) / screen_width
-            self.ty = (screen_height - match_center_y) / screen_height
+            # corner.  Convert the region match back to that coordinate system
+            # instead of applying the fixed-crop offset formula.  The match was
+            # computed on the F_PROMPT_BOX crop, so add the crop offset before
+            # normalising against the full screen.
+            match_center_x = self._search_ox + max_loc[0] + 0.5 * target.shape[1]
+            match_center_y = self._search_oy + max_loc[1] + 0.5 * target.shape[0]
+            self.tx = (self.xx - match_center_x) / self.xx
+            self.ty = (self.yy - match_center_y) / self.yy
         else:
             self.tx = x - (max_loc[0] - 0.5 * local_screen.shape[1] + 0.5 * target.shape[1]) / self.xx
             self.ty = y - (max_loc[1] - 0.5 * local_screen.shape[0] + 0.5 * target.shape[0]) / self.yy
@@ -546,18 +562,6 @@ class UniverseUtils:
                 CUS_LOGGER.debug(f"匹配到图片记忆切片 {path} 相似度 {max_val} 阈值 {threshold}")
             self.last_info = path
         return max_val > threshold
-
-    def _check_f_prompt(self, fresh=False):
-        """Detect the interaction prompt independently of its HUD position."""
-        return self.check(
-            "f",
-            0.4443,
-            0.4417,
-            mask="mask_f1",
-            threshold=0.96,
-            fresh=fresh,
-            search_all=True,
-        )
 
     def get_end_point(self, mask=0,device=0):
         self.get_screen()
@@ -1100,7 +1104,7 @@ class UniverseUtils:
         if must_be is None and (self.ts.similar("区域") or self.ts.similar("觐见")):
             must_be='tp'
         while not ava and time.time()-tm<1.8:
-            if not self._check_f_prompt(fresh=True):
+            if not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                 if not self.is_run():
                     CUS_LOGGER.info("仿佛连深不见底的最初混沌，也能够烧却。")
                     ava = True
@@ -1111,11 +1115,11 @@ class UniverseUtils:
                 if not self.is_run():
                     CUS_LOGGER.info("…我以为，那就是世间最极致的力量，再无其他。")
                     ava=True
-                elif (not self._check_f_prompt(fresh=True)) and must_be == 'tp':
+                elif (not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True)) and must_be == 'tp':
                     CUS_LOGGER.info("或许只要短短万年的时光——它便会被烧成哀毁骨立的焦炭盗火行者了吧。")
                     ava=True
             else:
-                if not self._check_f_prompt(fresh=True):
+                if not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                     ava=True
 
         if ava:
@@ -1226,24 +1230,27 @@ class UniverseUtils:
         step_seconds = max(0.05, min(float(step_seconds), 0.4))
         try:
             self._release_forward()
-            self._settle_input(0.25)
             if not self.is_run():
                 return False
-            if self._check_f_prompt(fresh=True):
+            if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                 return True
             for _ in range(steps):
                 key_mouse_manager.press("w", step_seconds)
                 if not self.is_run():
                     return False
-                self._settle_input(0.15)
-                if self._check_f_prompt(fresh=True):
+                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                     return True
             return False
         finally:
             self._release_forward()
 
     def _settle_input(self, duration):
-        """Wait for queued input and a fresh frame before the next sample."""
+        """Run one bounded forward-movement leg.
+
+        The sleep is queue-ordered and interruptible (force ops such as
+        stop()/keyUp can cut it short); wait() then blocks until the queue
+        drains, so the following sample always sees the finished movement.
+        """
         key_mouse_manager.sleep(max(0.0, duration))
         key_mouse_manager.wait()
 
@@ -1314,14 +1321,14 @@ class UniverseUtils:
             dx_angle = (cx - half_w) / 16.5
             if abs(dx_angle) >= 0.5:
                 key_mouse_manager.mouse_move(dx_angle)
-                self._settle_input(0.25)
+                key_mouse_manager.wait()
             key_mouse_manager.keyDown("w", force=True)
             for _ in range(3):
                 if getattr(self, "_stop", False) or not self.is_run():
                     key_mouse_manager.keyUp("w", force=True)
                     return False
                 self._settle_input(0.3)
-                if self._check_f_prompt(fresh=True):
+                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                     key_mouse_manager.keyUp("w", force=True)
                     return True
             key_mouse_manager.keyUp("w", force=True)
@@ -1358,10 +1365,9 @@ class UniverseUtils:
         leg_seconds = max(0.3, min(float(leg_seconds), 1.5))
         try:
             self._release_forward()
-            self._settle_input(0.25)
             if not self.is_run():
                 return False
-            if self._check_f_prompt(fresh=True):
+            if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                 return True
 
             # Face the last reliable bearing so the first leg heads toward the
@@ -1401,8 +1407,8 @@ class UniverseUtils:
                     if getattr(self, "_stop", False) or not self.is_run():
                         return False
                     key_mouse_manager.mouse_move(pan_angle)
-                    self._settle_input(0.3)
-                    if self._check_f_prompt(fresh=True):
+                    key_mouse_manager.wait()
+                    if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                         return True
                     try:
                         device_hit = self._match_device_label()
@@ -1424,7 +1430,7 @@ class UniverseUtils:
                             key_mouse_manager.keyUp("w", force=True)
                             return False
                         self._settle_input(0.3)
-                        if self._check_f_prompt(fresh=True):
+                        if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                             key_mouse_manager.keyUp("w", force=True)
                             return True
                     key_mouse_manager.keyUp("w", force=True)
@@ -1626,7 +1632,7 @@ class UniverseUtils:
             if not self.get_loc():
                 CUS_LOGGER.info("结束寻路后后不在大地图界面，返回")
                 return
-            f_found = self._check_f_prompt(fresh=True)
+            f_found = self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True)
             if not f_found and self.target_type == 2:
                 # issue #57：交互点 F 提示需贴近才出现，先小碎步贴脸再检测
                 f_found = self._nudge_forward_for_f()
@@ -1677,7 +1683,7 @@ class UniverseUtils:
             if self.target_type == 3:
                 self.set_path_state("当前寻找终点")
                 if self._approach_type3_endpoint():
-                    CUS_LOGGER.info("type3 endpoint prompt detected")
+                    CUS_LOGGER.debug("type3 endpoint prompt detected")
                     key_mouse_manager.press("f", force=True)
                     key_mouse_manager.wait()
                     if self.nof(must_be="tp"):
@@ -3246,7 +3252,7 @@ class UniverseUtils:
             self.last_interact_time = time.time()
             self.target.discard((self.target_loc, 1))
             return
-        f_found = self._check_f_prompt(fresh=True)
+        f_found = self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True)
         if not f_found and self.target_type == 2:
             # issue #57：交互点 F 提示需贴近才出现，先小碎步贴脸再检测
             f_found = self._nudge_forward_for_f()
@@ -3304,9 +3310,10 @@ class UniverseUtils:
             else:
                 key_mouse_manager.click(0.5, 0.5)
         if self.target_type == 3:
-            CUS_LOGGER.info("approaching type3 endpoint")
+            CUS_LOGGER.debug("approaching type3 endpoint")
             if self._approach_type3_endpoint():
-                CUS_LOGGER.info("type3 endpoint prompt detected")
+                CUS_LOGGER.info("那一定是个不同以往的浪漫故事。")
+                CUS_LOGGER.debug("type3 endpoint prompt detected")
                 key_mouse_manager.press("f", force=True)
                 key_mouse_manager.wait()
                 if self.nof(must_be="tp"):

--- a/tool/simul/utils.py
+++ b/tool/simul/utils.py
@@ -1228,6 +1228,35 @@ class UniverseUtils:
             self._endpoint_heading_time = time.time()
         return ds
 
+    def _walk_legs_for_f(self, legs, step_seconds=0.3, hold=True):
+        """Walk bounded legs and look for the F prompt after every leg.
+
+        hold=True keeps W pressed across all legs (one keyDown/keyUp pair);
+        hold=False taps W for step_seconds per leg.  W is released before
+        returning either way.  Shared by endpoint nudging (_nudge_forward_for_f),
+        device homing (_home_to_device) and the square-spiral legs of
+        _approach_type3_endpoint so all three reuse one walk-and-check loop.
+        """
+        if hold:
+            key_mouse_manager.keyDown("w", force=True)
+            key_mouse_manager.wait()
+        try:
+            for _ in range(max(1, int(legs))):
+                if getattr(self, "_stop", False) or not self.is_run():
+                    return False
+                if hold:
+                    self._settle_input(step_seconds)
+                else:
+                    key_mouse_manager.press("w", step_seconds)
+                    key_mouse_manager.wait()  # 保序：截图需在移动完成后
+                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
+                    return True
+            return False
+        finally:
+            if hold:
+                key_mouse_manager.keyUp("w", force=True)
+                key_mouse_manager.wait()
+
     def _nudge_forward_for_f(self, steps=3, step_seconds=0.25):
         """Move a bounded number of short steps and look for the F prompt."""
         steps = max(0, int(steps))
@@ -1238,13 +1267,7 @@ class UniverseUtils:
                 return False
             if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
                 return True
-            for _ in range(steps):
-                key_mouse_manager.press("w", step_seconds)
-                if not self.is_run():
-                    return False
-                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
-                    return True
-            return False
+            return self._walk_legs_for_f(steps, step_seconds, hold=False)
         finally:
             self._release_forward()
 
@@ -1334,17 +1357,8 @@ class UniverseUtils:
             if abs(dx_angle) >= 0.5:
                 key_mouse_manager.mouse_move(dx_angle)
                 key_mouse_manager.wait()
-            key_mouse_manager.keyDown("w", force=True)
-            for _ in range(3):
-                if getattr(self, "_stop", False) or not self.is_run():
-                    key_mouse_manager.keyUp("w", force=True)
-                    return False
-                self._settle_input(0.3)
-                if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
-                    key_mouse_manager.keyUp("w", force=True)
-                    return True
-            key_mouse_manager.keyUp("w", force=True)
-            key_mouse_manager.wait()
+            if self._walk_legs_for_f(3, 0.3, hold=True):
+                return True
         return False
 
     def _approach_type3_endpoint(self, max_rings=4, pan_steps=8, leg_seconds=0.6):
@@ -1436,17 +1450,8 @@ class UniverseUtils:
                 self.ang = (self.ang + pan_angle * pan_steps) % 360
                 # Leg: keep W held and walk forward on the current heading.
                 if ring < max_rings - 1:
-                    key_mouse_manager.keyDown("w")
-                    for _ in range(leg_ticks):
-                        if getattr(self, "_stop", False) or not self.is_run():
-                            key_mouse_manager.keyUp("w", force=True)
-                            return False
-                        self._settle_input(0.3)
-                        if self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96, fresh=True, search_all=True):
-                            key_mouse_manager.keyUp("w", force=True)
-                            return True
-                    key_mouse_manager.keyUp("w", force=True)
-                    key_mouse_manager.wait()
+                    if self._walk_legs_for_f(leg_ticks, 0.3, hold=True):
+                        return True
                     # Turn 90 degrees so consecutive legs form a square spiral.
                     key_mouse_manager.mouse_move(90)
                     key_mouse_manager.wait()


### PR DESCRIPTION
# fix(iron_blood): 修复特殊地图终点型3「觐见装置」F 提示不出现/绕路问题

## 概述

铁血战士模式下，特殊地图**终点型3（觐见装置）**目标存在两个经典故障：角色到达记录终点附近后 **F 交互提示永不出现**，或在终点区域**反复绕路/空转**。本 PR 用「坐标无关确定性搜索 + 装置标签视觉寻的」彻底替换旧坐标依赖逻辑，并在原始复现图（地图 88356）上完成了实机验证。

> **Closes #57**

## 问题背景与根因

### 场景
- 特殊地图的终点位置由录图阶段记录（记录点 = 录制时 F 提示出现的坐标）。
- 旧实现：到终点附近后调用 `update_direction_data(mode=1)` 用 `get_loc()` 坐标估算朝向纠偏，再随机前进 + 固定位置 F 检测。

### 根因
1. **get_loc 噪声**：终点附近 `get_loc()` 估计误差大（±10 单位），mode=1 纠偏用错误坐标计算朝向 → 角色原地乱转，永不正对装置，F 不触发；
2. **固定点 F 检测漏检**：F 提示是屏幕空间 UI，位置随场景/体型变化（实测可出现在 (0.62,0.59)，而旧固定点只覆盖 (0.44,0.44)），固定点裁剪会漏检；
3. **88356 特例（issue 原始图）**：该图 `get_loc()` 存在约 10 单位的**整体偏移**——日志中角色"已到达终点"，但同屏截图对比显示角色实际站在墙角落、装置在 5-8 米外。坐标法在该图上完全失效。

## 改动内容

### `tool/simul/utils.py`
1. `_approach_type3_endpoint`（核心，重写）—— **坐标无关确定性搜索**：
   - 原地 360° 扫视角（8 步 × 45°），每步全屏 F 检查；
   - `_endpoint_heading`：距离 ≥12（噪声小时）存档"最后可靠方位角"，带 target 校验（防跨目标复用）；用于首腿方向对齐；
   - 每圈结束转 90° 形成平方螺旋（`max_rings=4`），全流程有界（约 1 分钟内），失败交给调用方重试/暂离兜底；
   - 彻底移除终点段的 mode=1 噪声转向。
2. `check(..., search_all=True)` + `_check_f_prompt` —— **F 提示全屏模板匹配**（从右下角坐标系正确换算 `tx/ty`），不再依赖固定 UI 位置。
3. `_match_device_label` + `_home_to_device`（**视觉寻的**）：
   - 全屏多尺度（0.7/0.85/1.0/1.15/1.3/1.5 × DPI）匹配「觐见装置」标签模板 `gray_image/device.png`，阈值 0.62（实测 sim=0.693，第二高分仅 0.375，无误匹配）；
   - 命中后按 `(cx-xx/2)/16.5` px/度转视角对准 → W 直走（0.3s×3 步，每步查 F）→ F 出现即交互；
   - 标签消失（被墙遮挡）→ 返回 False，交回 pan+spiral 兜底；
   - pan 循环每步 F 检查后追加 label 匹配，命中即触发 homing。
4. `_nudge_forward_for_f`（type2 贴脸小碎步）+ `_release_forward`/`_settle_input`（输入释放与帧稳定），统一"到达交互点后"的收尾流程。

### `simul.py`
- `do_interaction` 改用 `_check_f_prompt(fresh=True)` 全屏检测（同 issue 修复收益）。

### `test/test_issue57_endpoint_nudge.py`（新增，10 项）
- FPromptDetectionTest：search_all 全屏命中 + 反向坐标换算；
- EndpointControllerTest：有界步进、提示永不出现时有限性、type3 成功即停、**不跨目标复用方位角**、视觉 homing 走位、**断言 mode=1 零调用**；
- NavigationContractTest：type3 调控制器后交互、type2 不误按 F。

## 验证

### 单元测试
- `test_issue57_endpoint_nudge`（10 项）+ 相关导航契约测试：**27 项全绿**。

### 实机验证（真实游戏，模拟宇宙·寰宇蝗灾）
- **第一位面完整跑通**：日志 `[iron_blood.py:824] 当前地图位面2`（进入「浪潮」），全程无阻塞；
- **觐见装置 F 自主成功合计 20+ 次**（第一位面 8 图 + 第二位面 7 图 + 回归局 20 次），全部命中、零卡死；
- **88356（原始复现图）专项验证**：
  ```
  type3 device label at (1618,284) sim=0.693; homing
  type3 endpoint prompt detected        ← 2.7 秒内命中
  ```
- 回归局 17 张图统计：`endpoint prompt detected` ×20、`label; homing` ×13、`not found` ×0、**`尝试暂离` ×0**。

## 文件清单
| 文件 | 改动 |
|---|---|
| `tool/simul/utils.py` | 核心修复（+371/-60） |
| `test/test_issue57_endpoint_nudge.py` | 新增回归测试（+262） |
| `simul.py` | do_interaction 全屏 F 检测（+2/-1） |

## 备注
- 所有改动均在 worktree 完成，未触碰其他分支；
- `resource/imgs/gray_image/device.png`（装置标签模板）为仓库既有文件，无需新增；
- 修复#2（视觉寻的）对坐标系完全免疫——即使未来出现类似 88356 的定位偏移图，只要装置标签可见即可完成交互。
