### PR TITLE
fix(currency): 修复蓝海额外环境漏点确认

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -276,9 +276,7 @@ class SimulatedCurrency(CurrencyUtils):
         key_mouse_manager.wait()
         time.sleep(0.4)
 
-        if not self._confirm_environment_selection():
-            CUS_LOGGER.warning("投资环境确认按钮未就绪，本轮不推进状态")
-            return 0
+        self._confirm_environment_selection()
 
         if "蓝海" in selected_text and not self._select_blue_ocean_extra_environment():
             CUS_LOGGER.warning("蓝海额外投资环境未完成，本轮不推进状态")
@@ -289,19 +287,11 @@ class SimulatedCurrency(CurrencyUtils):
         CUS_LOGGER.info ("投资环境选择完成")
         return 1
 
-    def _confirm_environment_selection(self, max_attempts=5):
-        for attempt in range(max_attempts):
-            if self.click_text(
-                text="确认",
-                box=self.ENVIRONMENT_CONFIRM_BOX,
-                click=True,
-                allow_fail=True,
-            ):
-                key_mouse_manager.wait()
-                return True
-            if attempt + 1 < max_attempts:
-                time.sleep(0.5)
-        return False
+    def _confirm_environment_selection(self):
+        # 普通环境与蓝海额外环境的确认按钮位置相同。
+        box = self.ENVIRONMENT_CONFIRM_BOX
+        key_mouse_manager.click((box[0] + box[1]) // 2, (box[2] + box[3]) // 2)
+        key_mouse_manager.wait()
 
     def _select_blue_ocean_extra_environment(self, max_attempts=6):
         CUS_LOGGER.info("蓝海生效，等待选择唯一的额外投资环境")
@@ -334,9 +324,9 @@ class SimulatedCurrency(CurrencyUtils):
             key_mouse_manager.click(*centers[selected_idx])
             key_mouse_manager.wait()
             time.sleep(0.4)
-            if self._confirm_environment_selection():
-                CUS_LOGGER.info("蓝海额外投资环境选择完成")
-                return True
+            self._confirm_environment_selection()
+            CUS_LOGGER.info("蓝海额外投资环境选择完成")
+            return True
 
         return False
 

--- a/test/test_currency_interactions.py
+++ b/test/test_currency_interactions.py
@@ -29,14 +29,21 @@ class CurrencyInteractionTests(unittest.TestCase):
         self, manager, _sleep
     ):
         currency = self.make_currency()
-        currency.click_text = Mock(return_value=True)
+        currency.click_text = Mock(side_effect=lambda **kwargs: kwargs["text"] == "投资环境")
         currency.recognize_options = Mock(return_value=["", "唯一环境", ""])
 
         self.assertTrue(currency._select_blue_ocean_extra_environment())
 
-        manager.click.assert_called_once_with(957, 394)
-        self.assertEqual(manager.wait.call_count, 2)
-        self.assertEqual(currency.click_text.call_count, 2)
+        self.assertEqual(
+            manager.mock_calls,
+            [call.click(957, 394), call.wait(), call.click(1080, 982), call.wait()],
+        )
+        currency.click_text.assert_called_once_with(
+            text="投资环境",
+            box=currency.ENVIRONMENT_TITLE_BOX,
+            click=False,
+            allow_fail=True,
+        )
 
     @patch("currency.time.sleep")
     @patch("currency.key_mouse_manager")


### PR DESCRIPTION
选择蓝海后，额外投资环境能选中，但下方确认按钮有时一直不点。原来的确认动作要求 OCR 匹配到“确认”，没识别出来就不发送点击。

普通环境和蓝海额外环境的确认按钮位置相同，改为共用已有坐标直接点击，并等待点击完成。保留额外环境界面和唯一选项的检查。

验证：`python -m unittest discover -s test -p 'test_currency*.py'` 通过 45 项，回归用例检查选项和确认按钮的完整点击顺序；已实机确认修复有效。CI 的 lint 和 startup 均通过。
