### PR TITLE
refactor(currency): 合并重复的动作执行流程

### DIFF
--- a/currency.py
+++ b/currency.py
@@ -565,12 +565,18 @@ class SimulatedCurrency(CurrencyUtils):
                     continue
 
                 name = action["name"]
-                CUS_LOGGER.info(f"{factor}触发并执行指令{name},条件：{trigger.get('text') or trigger['photo']}")
+                CUS_LOGGER.debug(
+                    "%s触发并执行指令%s，条件：%s",
+                    factor, name, trigger.get("text") or trigger["photo"],
+                )
                 interval = trigger.get("interval")
                 if interval and self.action_history and self.action_history[-1] == name:
                     elapsed = time.time() - self.action_time
                     if elapsed < interval:
-                        CUS_LOGGER.warning(f"触发时间限制，距离上次触发{elapsed}秒，默认配置间隔为{interval}")
+                        CUS_LOGGER.debug(
+                            "触发时间限制，距离上次触发%s秒，默认配置间隔为%s",
+                            elapsed, interval,
+                        )
                         return name, 1
 
                 result = None
@@ -581,7 +587,9 @@ class SimulatedCurrency(CurrencyUtils):
                 self.action_history = self.action_history[-10:]
                 self.action_time = time.time()
                 # 文字触发返回命中标志，图片触发保留最后一个动作的结果。
-                return name, 1 if text_trigger else (0 if result is None else result)
+                if text_trigger:
+                    return name, 1
+                return name, 0 if result is None else result
         return "", 0
 
     def _on_static_action_completed(self, action_name: str) -> None:

--- a/currency.py
+++ b/currency.py
@@ -515,23 +515,8 @@ class SimulatedCurrency(CurrencyUtils):
         self.update_state ("startbattle")
         return 1
 
-    def run_static (self, json_path = None, json_file = None, action_list = []) -> (str, int):
-        """
-        执行静态动作配置文件中的动作
-
-        根据提供的JSON配置文件或路径，查找并执行匹配的动作。
-        支持基于文本或图像的触发条件，一旦匹配成功即执行相应动作序列。
-
-        参数:
-            json_path: JSON配置文件路径，如果提供则加载该文件
-            json_file: 已加载的JSON配置对象，优先级高于json_path
-            action_list: 指定要执行的动作列表，为空则执行所有动作
-
-        返回值:
-            tuple: (触发的动作名称, 执行结果)
-                  - 触发的动作名称：空字符串表示未触发任何动作
-                  - 执行结果：0表示未触发，1表示触发成功，其他值表示部分成功
-        """
+    def run_static(self, json_path=None, json_file=None, action_list=None) -> tuple[str, int]:
+        """执行首个匹配的动作组，返回动作名和执行结果。"""
         if json_file is None:
             if json_path is None:
                 json_file = self.default_json
@@ -548,72 +533,56 @@ class SimulatedCurrency(CurrencyUtils):
                 self.update_state ("black")
         if np.mean (self.get_screen ()) > 12 and self.state == "black":
             self.update_state (self.last_state)
-        for j in action_list if len (action_list) else json_file:
-            for i in json_file[j]:
-                trigger = i["trigger"]
-                condition = trigger.get("condition", None)
-                #获取指定范围的文字
-                if trigger.get("text", None):
+        for group in action_list or json_file:
+            for action in json_file[group]:
+                trigger = action["trigger"]
+                condition = trigger.get("condition")
+                text_trigger = bool(trigger.get("text"))
+                if text_trigger:
                     text = self.ts.find_with_box(trigger["box"], redundancy=trigger.get("redundancy", 30))
-                    #强制跳过或者检查是否存在子串
-                    if (condition==self.state if condition is not None else True) and (len(text) and trigger["text"] in merge_text(text)):
-                        CUS_LOGGER.info(f"{factor}触发并执行指令{i['name']},条件：{trigger['text']}")
-                        if trigger.get("interval", None) and len(self.action_history) and self.action_history[-1] == i['name']:
-                            tm=time.time()-self.action_time
-                            if tm<trigger["interval"]:
-                                CUS_LOGGER.warning(f"触发时间限制，距离上次触发{tm}秒，默认配置间隔为{trigger["interval"]}")
-                                return i['name'], 1
-                        for j in i["actions"]:
-                            self.do_action(j)
-                        self._on_static_action_completed(i["name"])
-                        self.action_history.append(i["name"])
-                        #记录最近10个动作
-                        self.action_history = self.action_history[-10:]
-                        self.action_time=time.time()
-                        #返回触发的名字
-                        return i['name'],1
-                elif trigger.get("photo", None):
-                    resu=0
-                    if condition==self.state if condition is not None else True:
-                        if "pos" in trigger:
-                            if self.check(trigger["photo"], trigger["pos"]["x"], trigger["pos"]["y"], mask=trigger.get("mask", None), threshold=trigger.get("threshold", None),use_binary=trigger.get("binary", False)):
-                                CUS_LOGGER.info(f"{factor}触发并执行图像记忆切片指令,{i['name']}条件：{trigger['photo']}")
-                                if trigger.get("interval", None) and len(self.action_history) and self.action_history[
-                                    -1] == i['name']:
-                                    tm = time.time() - self.action_time
-                                    if tm < trigger["interval"]:
-                                        CUS_LOGGER.warning(f"触发时间限制，距离上次触发{tm}秒，默认配置间隔为{trigger["interval"]}")
-                                        return i['name'], 1
-                                for j in i["actions"]:
-                                    re=self.do_action(j)
-                                resu=re if re is not None else resu
-                                self._on_static_action_completed(i["name"])
-                                self.action_history.append(i["name"])
-                                #记录最近10个动作
-                                self.action_history = self.action_history[-10:]
-                                self.action_time = time.time()
-                                #返回触发的名字
-                                return i['name'],resu
-                        else:
-                            if self.click_target(find_image_by_name(trigger["photo"]), threshold=trigger.get("threshold", 0.9), flag=False,click=False):
-                                CUS_LOGGER.info(f"{factor}触发并执行世界全局图像记忆切片指令, {i['name']}条件:{trigger['photo']}")
-                                if trigger.get("interval", None) and len(self.action_history) and self.action_history[
-                                    -1] == i['name']:
-                                    tm = time.time() - self.action_time
-                                    if tm < trigger["interval"]:
-                                        CUS_LOGGER.warning( f"触发时间限制，距离上次触发{tm}秒，默认配置间隔为{trigger["interval"]}")
-                                        return i['name'], 1
-                                for j in i["actions"]:
-                                    re=self.do_action(j)
-                                resu=re if re is not None else resu
-                                self._on_static_action_completed(i["name"])
-                                self.action_history.append(i["name"])
-                                #记录最近10个动作
-                                self.action_history = self.action_history[-10:]
-                                self.action_time = time.time()
-                                #返回触发的名字
-                                return i['name'],resu
-        return '',0
+                    matched = (
+                        (condition is None or condition == self.state)
+                        and text
+                        and trigger["text"] in merge_text(text)
+                    )
+                elif trigger.get("photo"):
+                    if condition is not None and condition != self.state:
+                        continue
+                    if "pos" in trigger:
+                        matched = self.check(
+                            trigger["photo"], trigger["pos"]["x"], trigger["pos"]["y"],
+                            mask=trigger.get("mask"), threshold=trigger.get("threshold"),
+                            use_binary=trigger.get("binary", False),
+                        )
+                    else:
+                        matched = self.click_target(
+                            find_image_by_name(trigger["photo"]),
+                            threshold=trigger.get("threshold", 0.9), flag=False, click=False,
+                        )
+                else:
+                    continue
+                if not matched:
+                    continue
+
+                name = action["name"]
+                CUS_LOGGER.info(f"{factor}触发并执行指令{name},条件：{trigger.get('text') or trigger['photo']}")
+                interval = trigger.get("interval")
+                if interval and self.action_history and self.action_history[-1] == name:
+                    elapsed = time.time() - self.action_time
+                    if elapsed < interval:
+                        CUS_LOGGER.warning(f"触发时间限制，距离上次触发{elapsed}秒，默认配置间隔为{interval}")
+                        return name, 1
+
+                result = None
+                for step in action["actions"]:
+                    result = self.do_action(step)
+                self._on_static_action_completed(name)
+                self.action_history.append(name)
+                self.action_history = self.action_history[-10:]
+                self.action_time = time.time()
+                # 文字触发返回命中标志，图片触发保留最后一个动作的结果。
+                return name, 1 if text_trigger else (0 if result is None else result)
+        return "", 0
 
     def _on_static_action_completed(self, action_name: str) -> None:
         if action_name == RUN_START_ACTION:

--- a/currencywar.py
+++ b/currencywar.py
@@ -6,7 +6,6 @@ from currency import SimulatedCurrency
 from route import PATHS
 from tool import EXTRA
 from tool.log import CUS_LOGGER
-from tool.public_ocr import load_actions, merge_text
 
 
 class CurrencyWar (SimulatedCurrency):
@@ -19,8 +18,6 @@ class CurrencyWar (SimulatedCurrency):
         with EXTRA.FILE_LOCK:
             with open(settings_path, encoding="UTF-8") as file:
                 self.opt = json.load(file)
-        self.default_json_path = "actions/currencywar.json"
-        self.default_json = load_actions (self.default_json_path)
         CUS_LOGGER.info ("开始自动刷取叽米")
         super().__init__(
             find=True,                # 是否寻路，货币战争可能不需要，但必须传
@@ -31,32 +28,4 @@ class CurrencyWar (SimulatedCurrency):
             nums=self.opt.get("max_run_time", 0),
             bonus=False              # 是否领取沉浸奖励
         )
-
-    def check_text_in_box(self, box, target_text):
-        """
-        在屏幕截图的指定区域进行 OCR，判断 target_text 是否出现
-        box: [x1, x2, y1, y2] 像素坐标
-        返回 True/False
-        """
-        if not hasattr(self, 'screen') or self.screen is None:
-            return False
-        # 裁剪区域
-        x1, x2, y1, y2 = box
-        roi = self.screen[y1:y2, x1:x2]
-        if roi.size == 0:
-            return False
-        # 调用原项目的 OCR 函数（需要确认实际函数名和参数）
-        # 假设存在 tool.public_ocr.ocr_image 返回字符串列表
-        from tool.public_ocr import ocr_image
-        result = ocr_image(roi)   # 返回格式可能是 list of (text, confidence)
-        if result:
-            # 如果 result 是字符串列表
-            if isinstance(result[0], str):
-                text_list = result
-            else:
-                text_list = [item[0] for item in result]
-            merged = merge_text(text_list)
-            return target_text in merged
-        return False
-
 

--- a/test/test_currency_action_dispatch.py
+++ b/test/test_currency_action_dispatch.py
@@ -1,0 +1,136 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from currency import SimulatedCurrency
+
+
+class CurrencyActionDispatchTests(unittest.TestCase):
+    triggers = (
+        {"text": "\u51c6\u5907", "box": [0, 10, 0, 10], "redundancy": 20},
+        {"photo": "icon", "pos": {"x": 10, "y": 20}, "threshold": 0.8},
+        {"photo": "icon", "threshold": 0.8},
+    )
+
+    @staticmethod
+    def make_currency(trigger):
+        currency = object.__new__(SimulatedCurrency)
+        currency.state = "ready"
+        currency.get_screen = Mock(return_value=255)
+        currency.ts = Mock()
+        currency.ts.find_with_box.return_value = [
+            {"raw_text": "\u51c6\u5907", "box": [0, 10, 0, 10]}
+        ]
+        currency.check = Mock(return_value=True)
+        currency.click_target = Mock(return_value=True)
+        currency.action_history = []
+        currency.action_time = 0
+        currency.do_action = Mock()
+        currency._on_static_action_completed = Mock()
+        currency.default_json = {
+            "group": [{"name": "choice", "trigger": trigger, "actions": ["first", "last"]}]
+        }
+        return currency
+
+    @patch("currency.find_image_by_name", return_value="image")
+    @patch("currency.time.time", return_value=100)
+    def test_dispatch_preserves_result_order_and_history(self, _time, _image):
+        for trigger in self.triggers:
+            for last_result in (None, 0, 1):
+                with self.subTest(trigger=trigger, last_result=last_result):
+                    currency = self.make_currency(trigger)
+                    currency.action_history = [f"old-{i}" for i in range(10)]
+                    currency.do_action.side_effect = [1, last_result]
+                    sequence = Mock()
+                    sequence.attach_mock(currency.do_action, "action")
+                    sequence.attach_mock(currency._on_static_action_completed, "completed")
+
+                    result = currency.run_static()
+
+                    expected = 1 if "text" in trigger else (last_result or 0)
+                    self.assertEqual(result, ("choice", expected))
+                    self.assertEqual(
+                        sequence.mock_calls,
+                        [call.action("first"), call.action("last"), call.completed("choice")],
+                    )
+                    self.assertEqual(
+                        currency.action_history, [f"old-{i}" for i in range(1, 10)] + ["choice"]
+                    )
+                    self.assertEqual(currency.action_time, 100)
+                    if "text" in trigger:
+                        currency.ts.find_with_box.assert_called_once_with(
+                            trigger["box"], redundancy=20
+                        )
+                        currency.check.assert_not_called()
+                        currency.click_target.assert_not_called()
+                    elif "pos" in trigger:
+                        currency.check.assert_called_once_with(
+                            "icon", 10, 20, mask=None, threshold=0.8, use_binary=False
+                        )
+                        currency.click_target.assert_not_called()
+                    else:
+                        currency.click_target.assert_called_once_with(
+                            "image", threshold=0.8, flag=False, click=False
+                        )
+                        currency.check.assert_not_called()
+
+    @patch("currency.find_image_by_name", return_value="image")
+    @patch("currency.time.time", return_value=100)
+    def test_cooldown_does_not_execute_or_record_again(self, _time, _image):
+        for trigger in self.triggers:
+            with self.subTest(trigger=trigger):
+                currency = self.make_currency({**trigger, "interval": 10})
+                currency.action_history = ["choice"]
+                currency.action_time = 95
+
+                self.assertEqual(currency.run_static(), ("choice", 1))
+
+                currency.do_action.assert_not_called()
+                currency._on_static_action_completed.assert_not_called()
+                self.assertEqual(currency.action_history, ["choice"])
+                self.assertEqual(currency.action_time, 95)
+
+    @patch("currency.find_image_by_name", return_value="image")
+    def test_unmatched_trigger_or_state_does_not_run(self, _image):
+        for trigger in self.triggers:
+            for wrong_state in (False, True):
+                with self.subTest(trigger=trigger, wrong_state=wrong_state):
+                    currency = self.make_currency({**trigger, "condition": "ready"})
+                    if wrong_state:
+                        currency.state = "other"
+                    else:
+                        currency.ts.find_with_box.return_value = []
+                        currency.check.return_value = False
+                        currency.click_target.return_value = False
+
+                    self.assertEqual(currency.run_static(), ("", 0))
+
+                    currency.do_action.assert_not_called()
+                    currency._on_static_action_completed.assert_not_called()
+                    self.assertEqual(currency.action_history, [])
+
+    def test_group_filter_and_first_match_are_preserved(self):
+        currency = self.make_currency(self.triggers[0])
+        currency.default_json["selected"] = [
+            {"name": "selected", "trigger": self.triggers[0], "actions": ["selected"]},
+            {"name": "later", "trigger": self.triggers[0], "actions": ["later"]},
+        ]
+
+        self.assertEqual(currency.run_static(action_list=["selected"]), ("selected", 1))
+
+        currency.do_action.assert_called_once_with("selected")
+        currency._on_static_action_completed.assert_called_once_with("selected")
+
+    def test_failed_action_does_not_record_completion(self):
+        currency = self.make_currency(self.triggers[0])
+        currency.do_action.side_effect = RuntimeError("input failed")
+
+        with self.assertRaisesRegex(RuntimeError, "input failed"):
+            currency.run_static()
+
+        currency._on_static_action_completed.assert_not_called()
+        self.assertEqual(currency.action_history, [])
+        self.assertEqual(currency.action_time, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_currency_action_dispatch.py
+++ b/test/test_currency_action_dispatch.py
@@ -33,7 +33,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
 
     @patch("currency.find_image_by_name", return_value="image")
     @patch("currency.time.time", return_value=100)
-    def test_dispatch_preserves_result_order_and_history(self, _time, _image):
+    def test_dispatch_contract(self, _time, _image):
         for trigger in self.triggers:
             for last_result in (None, 0, 1):
                 with self.subTest(trigger=trigger, last_result=last_result):
@@ -75,7 +75,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
 
     @patch("currency.find_image_by_name", return_value="image")
     @patch("currency.time.time", return_value=100)
-    def test_cooldown_does_not_execute_or_record_again(self, _time, _image):
+    def test_cooldown_noop(self, _time, _image):
         for trigger in self.triggers:
             with self.subTest(trigger=trigger):
                 currency = self.make_currency({**trigger, "interval": 10})
@@ -90,7 +90,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
                 self.assertEqual(currency.action_time, 95)
 
     @patch("currency.find_image_by_name", return_value="image")
-    def test_unmatched_trigger_or_state_does_not_run(self, _image):
+    def test_unmatched_trigger(self, _image):
         for trigger in self.triggers:
             for wrong_state in (False, True):
                 with self.subTest(trigger=trigger, wrong_state=wrong_state):
@@ -108,7 +108,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
                     currency._on_static_action_completed.assert_not_called()
                     self.assertEqual(currency.action_history, [])
 
-    def test_group_filter_and_first_match_are_preserved(self):
+    def test_group_filter(self):
         currency = self.make_currency(self.triggers[0])
         currency.default_json["selected"] = [
             {"name": "selected", "trigger": self.triggers[0], "actions": ["selected"]},
@@ -120,7 +120,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
         currency.do_action.assert_called_once_with("selected")
         currency._on_static_action_completed.assert_called_once_with("selected")
 
-    def test_failed_action_does_not_record_completion(self):
+    def test_failed_action(self):
         currency = self.make_currency(self.triggers[0])
         currency.do_action.side_effect = RuntimeError("input failed")
 


### PR DESCRIPTION
货币战争的文字、局部图片和全屏图片触发，各写了一遍间隔判断、执行动作和记录历史。这几段合到 `run_static` 原函数末尾，后续改执行规则不用同步改三处。文字命中返回 1、图片返回最后一个动作结果的原有约定保留。

另外删掉了 `CurrencyWar` 中会被父类覆盖的动作配置加载，以及没有调用方的 `check_text_in_box`。后者还引用了不存在的 `ocr_image` 接口，实际流程用的是现有 OCR 实现。

正常触发和冷却等待的两条日志按开发规范改为 debug，避免正常流程反复输出警告。

新增的 5 项回归在清理前后均通过，覆盖三类触发、冷却间隔、状态条件、执行顺序、历史记录和异常中断。验证使用已有环境，不同步依赖：

- `uv run --no-sync python -m unittest discover -s test -p 'test_currency*.py'`：50 项通过。
- `uv run --no-sync ruff check . --exclude test --select=F821,E722,F403`：通过。
- `uv run --no-sync ruff check test/test_currency_action_dispatch.py`：通过。
- `uv run --no-sync python -c "import new_gui"`：通过。

已实机验证，另外检查了 112 个已跟踪 Python 文件的语法，均通过。
