### PR TITLE
fix(currency): 修复独立事件重复执行与物品详情浮层死锁

### DIFF
--- a/actions/currencywar.json
+++ b/actions/currencywar.json
@@ -243,7 +243,8 @@
             "text": "请选择强化角色",
             "box": [1415, 1565, 495, 522],
             "interval": 2,
-            "redundancy": 30
+            "redundancy": 30,
+            "once": true
         },
         "actions":
         [
@@ -261,7 +262,8 @@
             "text": "请选择强化角色",
             "box": [1415, 1565, 529, 556],
             "interval": 2,
-            "redundancy": 30
+            "redundancy": 30,
+            "once": true
         },
         "actions":
         [
@@ -279,7 +281,8 @@
             "text": "查看详情",
             "box": [625, 717, 329, 356],
             "interval": 2,
-            "redundancy": 30
+            "redundancy": 30,
+            "once": true
         },
         "actions":
         [   
@@ -294,7 +297,8 @@
             "text": "请选择一个祈愿试炼",
             "box": [1400, 1595, 572, 599],
             "interval": 2,
-            "redundancy": 30
+            "redundancy": 30,
+            "once": true
         },
         "actions":
         [
@@ -310,12 +314,41 @@
         ]
     },
     {
+        "name": "物品详情确认选择",
+        "trigger":{
+            "text": "确认选择",
+            "box": [700, 1250, 880, 1050],
+            "interval": 3
+        },
+        "actions":[
+            {
+                "text": "确认选择",
+                "box": [700, 1250, 880, 1050]
+            }
+        ]
+    },
+    {
+        "name": "物品详情弹层",
+        "trigger":{
+            "text": "装备",
+            "box": [750, 900, 150, 270],
+            "interval": 3,
+            "redundancy": 40
+        },
+        "actions":[
+            {
+                "press": "esc"
+            }
+        ]
+    },
+    {
         "name": "独家代言",
         "trigger":{
             "text": "查看详情",
             "box": [625, 1008, 329, 356],
             "interval": 2,
-            "redundancy": 30
+            "redundancy": 30,
+            "once": true
         },
         "actions":
         [

--- a/currency.py
+++ b/currency.py
@@ -148,7 +148,7 @@ class SimulatedCurrency(CurrencyUtils):
             # 无人命中超过10秒时记录整屏文字并留一张截图；战斗中长时间无触发属正常，跳过
             if time.time () - silent_time > 10:
                 silent_time = time.time ()
-                # 战斗界面判定与 tool/simul/utils.py 一致：自动战斗图标位于左上角
+                # 战斗判定复用 tool/simul/utils.py：模板是右下角的“行动中”文字（check 内坐标取反）
                 if self.check("auto_2", 0.0583, 0.0769):
                     continue
                 screen_text = " ".join(

--- a/currency.py
+++ b/currency.py
@@ -67,6 +67,8 @@ class SimulatedCurrency(CurrencyUtils):
         self.default_json_path = "actions/currencywar.json"
         self.default_json = load_actions(self.default_json_path)
         self.action_history = []
+        #已触发且触发条件仍成立的事件，条件消失后重新武装（见 run_static 的 once 触发）
+        self.latched_events = set()
         #策略最大刷新次数
         self.max_refresh = 1
         #运行次数
@@ -134,9 +136,32 @@ class SimulatedCurrency(CurrencyUtils):
 
     def loop (self):
         CUS_LOGGER.info ("开始OCR识别，等待触发文字")
+        silent_time = time.time ()
+        shot_saved = False
         while not self._stop:
             self.ts.forward (self.get_screen())
-            self.run_static ()
+            name, _ = self.run_static ()
+            if name:
+                silent_time = time.time ()
+                shot_saved = False
+                continue
+            # 无人命中超过10秒，说明当前界面在配置里没有对应事件，记录整屏文字并留一张截图
+            if time.time () - silent_time > 10:
+                silent_time = time.time ()
+                screen_text = " ".join(
+                    res["raw_text"]
+                    for res in self.ts.find_with_box([0, 1920, 0, 1080], redundancy=0)
+                )
+                CUS_LOGGER.warning("连续10秒无任何触发，当前屏幕文字：%s", screen_text)
+                if not shot_saved:
+                    shot_saved = True
+                    shot = os.path.join(
+                        PATHS["root"],
+                        "logs",
+                        f"unknown_screen_{time.strftime('%Y%m%d_%H%M%S')}.png",
+                    )
+                    cv2.imwrite(shot, np.array(self.screen))
+                    CUS_LOGGER.warning("已保存无触发界面截图：%s", shot)
 
     def goto_currency (self):
         """
@@ -552,9 +577,16 @@ class SimulatedCurrency(CurrencyUtils):
                 else:
                     continue
                 if not matched:
+                    #触发条件已消失，允许该事件下次重新触发
+                    self.latched_events.discard(action["name"])
                     continue
 
                 name = action["name"]
+                #once 事件在触发条件持续成立期间只执行一次，避免同一弹窗被重复处理
+                if trigger.get("once"):
+                    if name in self.latched_events:
+                        continue
+                    self.latched_events.add(name)
                 CUS_LOGGER.debug(
                     "%s触发并执行指令%s，条件：%s",
                     factor, name, trigger.get("text") or trigger["photo"],

--- a/currency.py
+++ b/currency.py
@@ -145,9 +145,12 @@ class SimulatedCurrency(CurrencyUtils):
                 silent_time = time.time ()
                 shot_saved = False
                 continue
-            # 无人命中超过10秒，说明当前界面在配置里没有对应事件，记录整屏文字并留一张截图
+            # 无人命中超过10秒时记录整屏文字并留一张截图；战斗中长时间无触发属正常，跳过
             if time.time () - silent_time > 10:
                 silent_time = time.time ()
+                # 战斗界面判定与 tool/simul/utils.py 一致：自动战斗图标位于左上角
+                if self.check("auto_2", 0.0583, 0.0769):
+                    continue
                 screen_text = " ".join(
                     res["raw_text"]
                     for res in self.ts.find_with_box([0, 1920, 0, 1080], redundancy=0)

--- a/test/test_currency_action_dispatch.py
+++ b/test/test_currency_action_dispatch.py
@@ -23,6 +23,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
         currency.check = Mock(return_value=True)
         currency.click_target = Mock(return_value=True)
         currency.action_history = []
+        currency.latched_events = set()
         currency.action_time = 0
         currency.do_action = Mock()
         currency._on_static_action_completed = Mock()
@@ -107,6 +108,77 @@ class CurrencyActionDispatchTests(unittest.TestCase):
                     currency.do_action.assert_not_called()
                     currency._on_static_action_completed.assert_not_called()
                     self.assertEqual(currency.action_history, [])
+
+    @patch("currency.find_image_by_name", return_value="image")
+    def test_once_trigger_not_repeated_until_text_disappears(self, _image):
+        """回归：弹窗文字持续存在时 once 事件只执行一次，且不阻塞其他事件。"""
+        currency = self.make_currency({**self.triggers[0], "once": True})
+        currency.default_json["group"].append(
+            {
+                "name": "later",
+                "trigger": {**self.triggers[0], "once": True},
+                "actions": ["later"],
+            }
+        )
+
+        self.assertEqual(currency.run_static(), ("choice", 1))
+
+        # 触发文字仍在屏幕上：once 事件跳过，后续事件照常匹配
+        currency.do_action.reset_mock()
+        self.assertEqual(currency.run_static(), ("later", 1))
+        self.assertEqual(currency.do_action.mock_calls, [call("later")])
+
+        # 两个事件都已锁存
+        currency.do_action.reset_mock()
+        self.assertEqual(currency.run_static(), ("", 0))
+        currency.do_action.assert_not_called()
+
+        # 触发文字消失后重新武装
+        currency.ts.find_with_box.return_value = []
+        self.assertEqual(currency.run_static(), ("", 0))
+
+        currency.ts.find_with_box.return_value = [
+            {"raw_text": "准备", "box": [0, 10, 0, 10]}
+        ]
+        self.assertEqual(currency.run_static(), ("choice", 1))
+
+    @patch("currency.cv2.imwrite")
+    @patch("currency.CUS_LOGGER")
+    @patch("currency.time.time", side_effect=[0, 5, 11, 15, 17])
+    def test_loop_reports_screen_text_when_nothing_matches(self, _time, logger, imwrite):
+        """回归：整屏无命中超过10秒时，记录屏幕文字并留一张截图备查。"""
+        currency = object.__new__(SimulatedCurrency)
+        currency._stop = False
+        currency.get_screen = Mock(return_value=object())
+        currency.screen = "frame"
+        currency.ts = Mock()
+        currency.ts.find_with_box.return_value = [
+            {"raw_text": "获得", "box": [0, 10, 0, 10]}
+        ]
+        runs = []
+
+        def run_static():
+            runs.append(1)
+            if len(runs) == 3:
+                currency._stop = True
+            return "", 0
+
+        currency.run_static = Mock(side_effect=run_static)
+
+        currency.loop()
+
+        currency.ts.find_with_box.assert_called_once_with(
+            [0, 1920, 0, 1080], redundancy=0
+        )
+        self.assertEqual(
+            logger.warning.call_args_list[0],
+            call("连续10秒无任何触发，当前屏幕文字：%s", "获得"),
+        )
+        self.assertEqual(
+            logger.warning.call_args_list[1].args[0],
+            "已保存无触发界面截图：%s",
+        )
+        imwrite.assert_called_once()
 
     def test_group_filter(self):
         currency = self.make_currency(self.triggers[0])

--- a/test/test_currency_action_dispatch.py
+++ b/test/test_currency_action_dispatch.py
@@ -150,6 +150,7 @@ class CurrencyActionDispatchTests(unittest.TestCase):
         currency = object.__new__(SimulatedCurrency)
         currency._stop = False
         currency.get_screen = Mock(return_value=object())
+        currency.check = Mock(return_value=False)
         currency.screen = "frame"
         currency.ts = Mock()
         currency.ts.find_with_box.return_value = [
@@ -179,6 +180,32 @@ class CurrencyActionDispatchTests(unittest.TestCase):
             "已保存无触发界面截图：%s",
         )
         imwrite.assert_called_once()
+
+    @patch("currency.cv2.imwrite")
+    @patch("currency.CUS_LOGGER")
+    @patch("currency.time.time", side_effect=[0, 5, 11, 15, 17])
+    def test_loop_skips_report_while_in_battle(self, _time, logger, imwrite):
+        """回归：战斗中长时间无触发属正常，不做记录也不存图。"""
+        currency = object.__new__(SimulatedCurrency)
+        currency._stop = False
+        currency.get_screen = Mock(return_value=object())
+        currency.check = Mock(return_value=True)
+        currency.ts = Mock()
+        runs = []
+
+        def run_static():
+            runs.append(1)
+            if len(runs) == 3:
+                currency._stop = True
+            return "", 0
+
+        currency.run_static = Mock(side_effect=run_static)
+
+        currency.loop()
+
+        currency.check.assert_called_once_with("auto_2", 0.0583, 0.0769)
+        logger.warning.assert_not_called()
+        imwrite.assert_not_called()
 
     def test_group_filter(self):
         currency = self.make_currency(self.triggers[0])

--- a/test/test_currencywar_actions.py
+++ b/test/test_currencywar_actions.py
@@ -31,6 +31,7 @@ class CurrencyWarActionsTest(unittest.TestCase):
                     "box": [1400, 1595, 572, 599],
                     "interval": 2,
                     "redundancy": 30,
+                    "once": True,
                 },
                 "actions": [
                     {"position": [684, 398]},
@@ -39,6 +40,40 @@ class CurrencyWarActionsTest(unittest.TestCase):
                 ],
             },
         )
+
+    def test_standalone_popup_events_trigger_once(self):
+        once_names = {
+            action["name"]
+            for action in self.actions
+            if action["trigger"].get("once")
+        }
+
+        self.assertEqual(
+            once_names,
+            {"盛会之星", "领航员", "啊哈大悦", "命运圣杯祈愿试炼", "独家代言"},
+        )
+
+    def test_item_detail_confirms_selection_before_escape(self):
+        names = [action.get("name") for action in self.actions]
+        confirm = next(
+            action
+            for action in self.actions
+            if action.get("name") == "物品详情确认选择"
+        )
+        detail = next(
+            action
+            for action in self.actions
+            if action.get("name") == "物品详情弹层"
+        )
+
+        self.assertEqual(confirm["trigger"]["text"], "确认选择")
+        self.assertEqual(
+            confirm["actions"],
+            [{"text": "确认选择", "box": [700, 1250, 880, 1050]}],
+        )
+        self.assertEqual(detail["trigger"]["text"], "装备")
+        self.assertEqual(detail["actions"], [{"press": "esc"}])
+        self.assertLess(names.index("物品详情确认选择"), names.index("物品详情弹层"))
 
     def test_run_history_actions_keep_expected_names(self):
         action_names = {action.get("name") for action in self.actions}


### PR DESCRIPTION
## 问题与结果

货币战争里独立出来的弹窗事件原先没有任何状态，只要 OCR 识别到触发文字就会执行：

- `interval` 冷却只比较「上一个动作」，中间插进任意其他动作后，同一弹窗会被再执行一次。
  盛会之星因此重复执行，第二次执行的盲点误入角色详情面板。
- 独家代言、啊哈大悦点开物品详情浮层后，没有任何事件处理该界面，整屏零命中导致流程长时间停滞
  （实测停滞 80 分钟，直到手动停止）。

本次修改后：带 `once` 标记的事件在触发条件持续成立期间只执行一次，条件消失后自动重新武装；
物品详情浮层会被自动确认或关闭；整屏零命中时自动留下界面文字与截图，且战斗期间不再记录。

## 实现与影响

- 复用 `run_static` 既有的「首个匹配即执行」流程，在 `currency.py` 内新增事件锁存集合 `latched_events`，
  不引入新的状态机，也不占用全局 `self.state`。被锁存的事件走 `continue`，因此不会阻塞其他事件的匹配。
- `actions/currencywar.json`：盛会之星、领航员、啊哈大悦、命运圣杯祈愿试炼、独家代言标记 `"once": true`；
  新增「物品详情确认选择」（用 `text` 动作自定位点击，不需要标定坐标）与「物品详情弹层」（页眉 `装备` → ESC）。
- 配置兼容性：`once` 是新增的可选字段，未标记的事件行为完全不变；`latched_events` 是实例属性，重新开局即清空。
- `currency.py::loop` 连续 10 秒无任何触发时，用 WARNING 记录整屏 OCR 文字，并把当前帧保存为
  `logs/unknown_screen_<时间戳>.png`（读 OCR 缓存，不额外增加识别开销）。
- 同一处复用 `tool/simul/utils.py:1744` 已有的战斗判定，战斗持续必然超过 10 秒，属于正常无触发，直接跳过记录：
  - 模板：`resource/imgs/auto_2.jpg`（82×24，内容是「行动中」文字）
  - `check("auto_2", 0.0583, 0.0769)`：`get_local` 内部对 x、y 取反，该参数实际检查画面**右下角**
    （即战斗界面右下角的「我方/敌方行动中」指示）
  - 阈值沿用默认 `self.threshold = 0.97`；判定只在静默满 10 秒后执行一次，开销可忽略

## 验证

- `uv run --no-sync python -m unittest test_currency_action_dispatch test_currencywar_actions test_currency_interactions test_currency_difficulty_selection test_currency_investment_selection test_currency_investment_state test_currency_run_history test_currency_settings`
  → **53 tests OK**
- `uv run --no-sync ruff check currency.py test/test_currency_action_dispatch.py test/test_currencywar_actions.py` → 通过
- `actions/currencywar.json` JSON 解析通过（38 个事件）
- 实机（维护者完成）：ESC 可以关闭物品详情浮层；点击「确认选择」可以完成选择
- 实机待观察：战斗期间不再出现 `连续10秒无任何触发`（依赖 `auto_2` 模板在货币战争战斗 HUD 的命中率）

## 未完成项

- 详情浮层的前置触发条件尚未完全定位：维护者在装备选择界面用脚本点击 `(809,291)` 未复现停滞，
  因此「点击即打开详情」不成立，具体叠加因素（对局状态、时序）仍未确认。本 PR 以自愈方式兜底，不依赖该结论。
- `simul.py`、`diver.py` 中存在同源的 `run_static` 复制实现，同样缺少事件级去重，本 PR 未涉及。