### PR TITLE
pref(any_fate): 完善银狼秘技适配、完善“遇猪切人”功能

### DIFF
--- a/any_fate.py
+++ b/any_fate.py
@@ -229,10 +229,11 @@ class AnyFateUniverse(SimulatedUniverse):
                 else:
                     self.switch_current_role(num=1)
                 # 根据图像识别结果，判断是否施放银狼秘技
-                if "黑塔的办公" not in self.area and self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
-                    key_mouse_manager.press('e')
-                    CUS_LOGGER.debug("已施放银狼秘技")
-                    time.sleep(0.8)
+                if "黑塔的办公" not in self.area:
+                    if self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
+                        key_mouse_manager.press('e')
+                        CUS_LOGGER.debug("已施放银狼秘技")
+                        time.sleep(0.8)
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)
                         and self.loaded_map_root not in (None, battle_map_root)):

--- a/any_fate.py
+++ b/any_fate.py
@@ -233,7 +233,8 @@ class AnyFateUniverse(SimulatedUniverse):
                     if self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
                         key_mouse_manager.press('e')
                         CUS_LOGGER.debug("已施放银狼秘技")
-                        key_mouse_manager.sleep(0.8)
+                        key_mouse_manager.sleep(0.6)
+                key_mouse_manager.wait()
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)
                         and self.loaded_map_root not in (None, battle_map_root)):

--- a/any_fate.py
+++ b/any_fate.py
@@ -113,7 +113,6 @@ class AnyFateUniverse(SimulatedUniverse):
         self.max_limited = None
         self.run_start_time = time.time()
         self.need_end=False
-        self.tm_attack = 0 # 上次空打一拳时间
         self.record = self.opt.get("recording_iron_blood", True)
         self.recorder = WindowRecorder('logs/video/', fps=30, window_title="崩坏：星穹铁道",window_class_name="UnityWndClass",see_time=self.opt.get("record_add_label", True), offsets=[10, 50, 10, 10], overlay_map=self.opt.get("record_add_label", True) and self._show_map, simul_instance=self)
         self.del_record_time=self.opt.get("del_record_time", 31)
@@ -235,11 +234,6 @@ class AnyFateUniverse(SimulatedUniverse):
                         key_mouse_manager.press('e')
                         CUS_LOGGER.debug("已施放银狼秘技")
                         key_mouse_manager.sleep(0.6)
-                    # 攻击附近潜在的可破坏物，5秒内不重复攻击
-                    if time.time() - self.tm_attack >= 5:
-                        key_mouse_manager.click(0.5, 0.5)
-                        CUS_LOGGER.debug("尝试空打一拳")
-                        self.tm_attack = time.time()
                 key_mouse_manager.wait()
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)

--- a/any_fate.py
+++ b/any_fate.py
@@ -233,7 +233,7 @@ class AnyFateUniverse(SimulatedUniverse):
                     if self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
                         key_mouse_manager.press('e')
                         CUS_LOGGER.debug("已施放银狼秘技")
-                        time.sleep(0.8)
+                        key_mouse_manager.sleep(0.8)
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)
                         and self.loaded_map_root not in (None, battle_map_root)):

--- a/any_fate.py
+++ b/any_fate.py
@@ -113,6 +113,7 @@ class AnyFateUniverse(SimulatedUniverse):
         self.max_limited = None
         self.run_start_time = time.time()
         self.need_end=False
+        self.tm_attack = 0 # 上次空打一拳时间
         self.record = self.opt.get("recording_iron_blood", True)
         self.recorder = WindowRecorder('logs/video/', fps=30, window_title="崩坏：星穹铁道",window_class_name="UnityWndClass",see_time=self.opt.get("record_add_label", True), offsets=[10, 50, 10, 10], overlay_map=self.opt.get("record_add_label", True) and self._show_map, simul_instance=self)
         self.del_record_time=self.opt.get("del_record_time", 31)
@@ -228,12 +229,17 @@ class AnyFateUniverse(SimulatedUniverse):
                         self.switch_current_role(num=1)
                 else:
                     self.switch_current_role(num=1)
-                # 根据图像识别结果，判断是否施放银狼秘技
                 if "黑塔的办公" not in self.area:
+                    # 根据图像识别结果，判断是否施放银狼秘技
                     if self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
                         key_mouse_manager.press('e')
                         CUS_LOGGER.debug("已施放银狼秘技")
                         key_mouse_manager.sleep(0.6)
+                    # 攻击附近潜在的可破坏物，5秒内不重复攻击
+                    if time.time() - self.tm_attack >= 5:
+                        key_mouse_manager.click(0.5, 0.5)
+                        CUS_LOGGER.debug("尝试空打一拳")
+                        self.tm_attack = time.time()
                 key_mouse_manager.wait()
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)

--- a/any_fate.py
+++ b/any_fate.py
@@ -206,21 +206,6 @@ class AnyFateUniverse(SimulatedUniverse):
                 self.quan = 1
             elif not self.bai_e and self.check("bai_e", 0.0625,0.7092):
                 self.bai_e = 1
-            # 当前节点为祝福猪节点时切2号位并重置黄泉/白厄状态
-            start_node = getattr(self, 'start_nodes', None)
-            if start_node is not None:
-                cm = (start_node.get('orig') or {}).get('corner_marker')
-                if cm and cm.get('name') in ('pig1', 'pig2'):
-                    CUS_LOGGER.info("梦中那刺骨的愤怒与对自我的憎恨仍在震动着他的心。")
-                    # 根据用户设置决定是否遇猪切换2号位角色
-                    if self.opt.get("pig_switch_2_role", False):
-                        self.switch_current_role(num=2)
-                        self.quan = 0
-                        self.bai_e = 0
-                else:
-                    self.switch_current_role(num=1)
-            else:
-                self.switch_current_role(num=1)
             #上次交互时间
             self.last_interact_time = bk_lst_changed
             # 刚进图，初始化一些数据
@@ -228,8 +213,23 @@ class AnyFateUniverse(SimulatedUniverse):
                 ocr_text = self.ts.find_with_box(box=[55, 164, 12, 40],forward=True,re_screen=False)
                 self.area=merge_text(ocr_text) if len(ocr_text) else ""
                 CUS_LOGGER.debug(f"当前区域{self.area}")
+                # 当前节点为祝福猪节点时切2号位并重置黄泉/白厄状态
+                start_node = getattr(self, 'start_nodes', None)
+                if "精英" not in self.area and start_node is not None:
+                    cm = (start_node.get('orig') or {}).get('corner_marker')
+                    if cm and cm.get('name') in ('pig1', 'pig2'):
+                        CUS_LOGGER.info("梦中那刺骨的愤怒与对自我的憎恨仍在震动着他的心。")
+                        # 根据用户设置决定是否遇猪切换2号位角色
+                        if self.opt.get("pig_switch_2_role", False):
+                            self.switch_current_role(num=2)
+                            self.quan = 0
+                            self.bai_e = 0
+                    else:
+                        self.switch_current_role(num=1)
+                else:
+                    self.switch_current_role(num=1)
                 # 根据图像识别结果，判断是否施放银狼秘技
-                if self.area != "黑塔的办公" and self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
+                if "黑塔的办公" not in self.area and self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
                     key_mouse_manager.press('e')
                     CUS_LOGGER.debug("已施放银狼秘技")
                     time.sleep(0.8)

--- a/any_fate.py
+++ b/any_fate.py
@@ -223,13 +223,14 @@ class AnyFateUniverse(SimulatedUniverse):
             self.last_interact_time = bk_lst_changed
             # 刚进图，初始化一些数据
             if not self.need_end:
-                # 根据图像识别结果，判断是否施放银狼秘技
-                if self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
-                    key_mouse_manager.press('e')
-                    CUS_LOGGER.debug("已施放银狼秘技")
                 ocr_text = self.ts.find_with_box(box=[55, 164, 12, 40],forward=True,re_screen=False)
                 self.area=merge_text(ocr_text) if len(ocr_text) else ""
                 CUS_LOGGER.debug(f"当前区域{self.area}")
+                # 根据图像识别结果，判断是否施放银狼秘技
+                if self.area != "黑塔的办公" and self.current_role == 1 and self.check("silverwolf", 0.0609,0.7037) and (not self.check("bean", 0.1536,0.7056)):
+                    key_mouse_manager.press('e')
+                    CUS_LOGGER.debug("已施放银狼秘技")
+                    time.sleep(0.8)
                 battle_map_root = os.path.join(PATHS["image"], "nmaps")
                 if (("战斗" in self.area or "精英" in self.area or "首领" in self.area)
                         and self.loaded_map_root not in (None, battle_map_root)):


### PR DESCRIPTION
1、当处于“黑塔的办公”区域时，不施放银狼秘技。
2、如果是祝福扑满精英格，则不切人。因为精英格内探索态的敌人表现形式仍为精英敌人，而非扑满。
3、每隔一段时间（每次执行any_fate.py中的normal()时）攻击一次，尝试攻击附近可能存在的可破坏物。实测可以攻击到大多数可破坏物，且额外消耗的时间相比演算总时间增量很少，不影响权杖运行。适合远程角色，尚未测试近程角色。（或者做成用户可选项？）